### PR TITLE
Fixed the Headers for Shift Table

### DIFF
--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -44,11 +44,11 @@ export default function ShiftTable({
             accessor: 'day',
         },
         {
-            Header: 'Shift start',
+            Header: 'Shift Start',
             accessor: 'shiftStart',
         },
         {
-            Header: 'Shift end',
+            Header: 'Shift End',
             accessor: 'shiftEnd',
         },
         {
@@ -60,7 +60,7 @@ export default function ShiftTable({
               ),
         },
         {
-            Header: 'Backup driver',
+            Header: 'Backup Driver',
             accessor: 'driverBackupID',
             Cell: ({ value }) => (
                 // Stryker disable next-line all : hard to set up test

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
 
 const mockedNavigate = jest.fn();
 
-const expectedHeaders = ["id", "Day", "Shift start", "Shift end", "Driver", "Backup driver"];
+const expectedHeaders = ["id", "Day", "Shift Start", "Shift End", "Driver", "Backup Driver"];
 const expectedFields = ["id", "day", "shiftStart", "shiftEnd", "driverID", "driverBackupID"];
 const testId = "ShiftTable";
 describe("ShiftTable tests", () => {


### PR DESCRIPTION
When looking at the shift table some of the headers are inconsistent so I made changes to ShiftTable.js to make sure all the labels are consistent. Now all of the words in the headers are capitalized for the shift table (both as a driver or admin). 

<img width="1352" alt="Screenshot 2024-05-16 at 5 27 10 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/0b8d0168-8879-4e83-92bd-1fcb098daca8">

Close #8