### PR TITLE
Anika - Non-Admin Users CanNOT Access Driver List

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -36,7 +36,7 @@ public class DriversController extends ApiController{
     ObjectMapper mapper;
 
     @Operation(summary = "Get a list of all drivers")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/all")
     public ResponseEntity<String> drivers()
             throws JsonProcessingException {

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
@@ -42,6 +42,14 @@ public class DriversControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
+
+@WithMockUser(roles = { "USER" })
+  @Test
+  public void returns_no_info_for_non_admin() throws Exception {
+    mockMvc.perform(get("/api/drivers/all"))
+        .andExpect(status().is(403));
+  }
+
   @Test
   public void users__logged_out_get() throws Exception {
     mockMvc.perform(get("/api/drivers/get?id=42"))


### PR DESCRIPTION
Anika - Non-admin users now get FORBIDDEN error when trying to access driver list from Swagger UI endpoint.
running npm test and npm run coverage is still 100, everything seems to work and now if you log in as a non-admin user and try to get list of all drivers you will get a 403 FORBIDDEN error. But if you login from an admin account you should get 200 signal and a list of all drivers. So now non-admin users don't have access.
Closes #11 