### PR TITLE
liz - add "assigned" column to rides table

### DIFF
--- a/frontend/src/fixtures/rideFixtures.js
+++ b/frontend/src/fixtures/rideFixtures.js
@@ -62,7 +62,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC156",
             "notes": "2 people",   
-            "shiftId": "10"
+            "shiftId": "0"
         },
         
     ],

--- a/frontend/src/main/components/Ride/RideTable.js
+++ b/frontend/src/main/components/Ride/RideTable.js
@@ -155,14 +155,10 @@ export default function RideTable({
         },
         {
             Header: 'Assigned?',
-            accessor: 'assigned',
-            Cell: ({ value }) => {
-                if (!value) {
-                    return 'unassigned';
-                } else {
-                    return 'assigned';
-                }
-            },
+            accessor: 'shiftId',
+            Cell: ({ value }) => (
+                value === '0' ? 'unassigned' : 'assigned'
+            ),
         },
         {
             Header: 'Course #',

--- a/frontend/src/main/components/Ride/RideTable.js
+++ b/frontend/src/main/components/Ride/RideTable.js
@@ -154,6 +154,17 @@ export default function RideTable({
             accessor: 'day',
         },
         {
+            Header: 'Assigned?',
+            accessor: 'assigned',
+            Cell: ({ value }) => {
+                if (!value) {
+                    return 'unassigned';
+                } else {
+                    return 'assigned';
+                }
+            },
+        },
+        {
             Header: 'Course #',
             accessor: 'course',
         },

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -151,6 +151,12 @@ describe("RideTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
+    const assigned = getByTestId(`${testId}-cell-row-0-col-assigned`);
+    expect(assigned).toHaveTextContent('assigned');
+
+    const unassigned = getByTestId(`${testId}-cell-row-2-col-assigned`);
+    expect(unassigned).toHaveTextContent('unassigned');
+
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
 

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -152,10 +152,10 @@ describe("RideTable tests", () => {
     });
 
     const assigned = getByTestId(`${testId}-cell-row-0-col-shiftId`);
-    expect(assigned).toHaveTextContent('assigned');
+    expect(assigned).toHaveTextContent(/^assigned$/);
 
     const unassigned = getByTestId(`${testId}-cell-row-2-col-shiftId`);
-    expect(unassigned).toHaveTextContent('unassigned');
+    expect(unassigned).toHaveTextContent(/^unassigned$/);
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -137,8 +137,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day', 'Assigned?', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
+    const expectedFields = ['id', 'day', 'assigned', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -138,7 +138,7 @@ describe("RideTable tests", () => {
     );
 
     const expectedHeaders = ['id','Day', 'Assigned?', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'assigned', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedFields = ['id', 'day', 'shiftId', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -151,10 +151,10 @@ describe("RideTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    const assigned = getByTestId(`${testId}-cell-row-0-col-assigned`);
+    const assigned = getByTestId(`${testId}-cell-row-0-col-shiftId`);
     expect(assigned).toHaveTextContent('assigned');
 
-    const unassigned = getByTestId(`${testId}-cell-row-2-col-assigned`);
+    const unassigned = getByTestId(`${testId}-cell-row-2-col-shiftId`);
     expect(unassigned).toHaveTextContent('unassigned');
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");


### PR DESCRIPTION
Closes #7 

Adds one extra column to the riders' view of the "rides" table which has the text "unassigned" if the ride's shiftId is "0" and "assigned" otherwise.

Also modified the fixtures to demonstrate assigned vs unassigned rides (previously all fixture rides were assigned)

storybook link: [here](https://ucsb-cs156-s24.github.io/proj-gauchoride-s24-5pm-6/prs/23/storybook/?path=/story/components-ride-ridetable--rider-three-subjects-with-buttons)

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/31554550/3dc0b4cd-8587-478a-9229-99e95283eb73)
