### PR TITLE
Yuji RiderNavBar Updates

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,14 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_ADMIN") && isParticipant(currentUser) && (
-                  <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
-                    <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
-                  </NavDropdown>
-                )
-              }
-              {
-                hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && isParticipant(currentUser) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                     <NavDropdown.Item data-testid="appnavbar-availability-dropdown-availabilities" as={Link} to="/availability/">Availability</NavDropdown.Item>
@@ -120,7 +113,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && isParticipant(currentUser) && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,7 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && isParticipant(currentUser) && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN"))  (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                     <NavDropdown.Item data-testid="appnavbar-availability-dropdown-availabilities" as={Link} to="/availability/">Availability</NavDropdown.Item>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -113,7 +113,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && isParticipant(currentUser) && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,7 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN"))  (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                     <NavDropdown.Item data-testid="appnavbar-availability-dropdown-availabilities" as={Link} to="/availability/">Availability</NavDropdown.Item>
@@ -113,7 +113,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,7 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
+                hasRole(currentUser, "ROLE_ADMIN") && isParticipant(currentUser) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                   </NavDropdown>
@@ -120,7 +120,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                isParticipant(currentUser) && (
+                hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -197,6 +197,24 @@ describe("AppNavbar tests", () => {
         expect(shiftMenu).toBeInTheDocument();        
     });
 
+    test("does NOT render shift table links for rider", async () => {
+
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const shiftMenu = screen.queryByTestId("appnavbar-shift-dropdown");
+        expect(shiftMenu).not.toBeInTheDocument();        
+    });
+
     test("not render shift table links for regular user", async () => {
 
         const currentUser = currentUserFixtures.userOnly;
@@ -566,7 +584,7 @@ describe("AppNavbar tests", () => {
 
     });
 
-    test("Driver page link should appear for a user that is not a driver", async () => {
+    test("Driver page link should appear for a user that is a driver", async () => {
         const currentUser = currentUserFixtures.driverOnly;
         const doLogin = jest.fn();
 
@@ -581,6 +599,23 @@ describe("AppNavbar tests", () => {
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
         const driverLink = screen.queryByTestId("appnavbar-driver");
         expect(driverLink).toBeInTheDocument();      
+    });
+
+    test("Driver page link should NOT appear for a user that is a rider", async () => {
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver");
+        expect(driverLink).not.toBeInTheDocument();      
     });
         
     test("renders RiderApplicationMember links correctly for member", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -179,9 +179,9 @@ describe("AppNavbar tests", () => {
         await waitFor(() => expect(screen.queryByText(/^Drivers$/)).not.toBeInTheDocument());
     });
 
-    test("renders shift table links correctly for rider", async () => {
+    test("renders shift table links correctly for driver", async () => {
 
-        const currentUser = currentUserFixtures.riderOnly;
+        const currentUser = currentUserFixtures.driverOnly;
         const doLogin = jest.fn();
 
         const { getByText , getByTestId } = render(


### PR DESCRIPTION
Fixed bug where not riders can access dropdown for Shifts and Drivers Page button on the navbar. 
Made changes to the test file to make sure shifts and drivers page navbar buttons are hidden for riders. 

Extra: 
Made additional edits to navbar for adminOnly users so all the required information is shown.
Made sure admin users with multiple roles won't have duplicate navbar buttons.

Dokku Deployment: https://proj-gauchoride-yuji-sakaguchi-dev.dokku-14.cs.ucsb.edu/

Closes #9 

New Riders User (No more Shifts, Drivers Page)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/fff6ee1f-001b-4db6-81ff-4a490a18acb4)

New AdminOnly User (Added Shifts Availability as part of Shifts Dropdown, Drivers Page)
(No need to add admin as driver role to see Drivers Page now)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/a73a6c21-c710-4c71-95ad-e4729c82c457)