### PR TITLE
Wesley - FIX for Driver Availabilities page having error message toasts for Driver users

### DIFF
--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/admin/all" },
+            { method: "GET", url: "/api/driverAvailability" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
@@ -13,7 +13,7 @@ export default function DriverAvailabilityIndexPage() {
     const { data: availabilities, error: _error, status: _status } =
         useBackend(
             // Stryker disable all : hard to test for query caching
-            ["/api/driverAvailability/admin/all"],
+            ["/api/driverAvailability"],
             { method: "GET", url: "/api/driverAvailability/admin/all" },
             []
             // Stryker restore all 

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
@@ -13,7 +13,7 @@ export default function DriverAvailabilityIndexPage() {
     const { data: availabilities, error: _error, status: _status } =
         useBackend(
             // Stryker disable all : hard to test for query caching
-            ["/api/driverAvailability"],
+            ["/api/driverAvailability/admin/all"],
             { method: "GET", url: "/api/driverAvailability/admin/all" },
             []
             // Stryker restore all 

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -45,7 +45,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     test("fetches driverAvailabilities using the correct GET method", async () => {
         setupAdminUser();
-        axiosMock.onGet("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  // Ensures the method is GET
                 return [200, driverAvailabilityFixtures.threeAvailability];
             }
@@ -76,7 +76,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
         // This variable will help us verify that the correct method was used.
         let wasGetMethodUsed = false;
     
-        axiosMock.onAny("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  
                 wasGetMethodUsed = true; 
                 return [200, driverAvailabilityFixtures.threeAvailability];


### PR DESCRIPTION
Closes #10 

Issue summary: Navigating to Shifts --> Availability as a Driver user shows error toasts, and does not display their driver availabilities.

Steps to reproduce error:
1. Navigate to https://gauchoride.dokku-14.cs.ucsb.edu/availability/
2. Log in as a user with only the "driver" role (admin user can set this through Admin --> Users)
3. Navigate to Shifts --> Availability
4. Error message toasts should pop up, and the user's driver availabilities are not visible

Steps to verify error no longer persists:
1. Navigate to https://project-jeffsmithepic-2.dokku-14.cs.ucsb.edu/ (Dev deployment)
2. Log in as a user with only the "driver" role (admin user can set this through Admin --> Users)
3. Navigate to Shifts --> Availability
4. Error message toasts no longer pop up, and the user can see all driver availabilities matching their driver ID (may be empty if none exist)

Page as a driver user:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/55602614/895ccf70-0363-439b-b738-e34118dc6863)

Page as an admin user:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/55602614/e7d74252-822f-40d3-a22f-13bfcefca57f)

