### PR TITLE
Diya new driver index page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14341,9 +14341,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
+      "version": "1.0.30001485",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
+      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -46664,9 +46664,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew=="
+      "version": "1.0.30001485",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
+      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14341,9 +14341,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==",
+      "version": "1.0.30001620",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
       "funding": [
         {
           "type": "opencollective",
@@ -46664,9 +46664,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA=="
+      "version": "1.0.30001620",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/driverAvailabilityUtils"
@@ -14,10 +15,6 @@ export default function DriverAvailabilityTable({
 
     const editCallback = (cell) => {
         navigate(`/availability/edit/${cell.row.values.id}`)
-    }
-
-    const reviewCallback = (cell) => {
-        navigate(`/admin/availability/review/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching
@@ -40,6 +37,10 @@ export default function DriverAvailabilityTable({
         {
             Header: 'Driver Id',
             accessor: 'driverId',
+            Cell: ({ value }) => (
+                // Stryker disable next-line all : hard to set up test
+                <Link to={`/driverInfo/${value}`}>{value}</Link>
+              ),
         },
         {
             Header: 'Day',
@@ -68,7 +69,6 @@ export default function DriverAvailabilityTable({
 
     const buttonColumnsAdmin = [
         ...columns,
-        ButtonColumn("Review", "primary", reviewCallback, "DriverAvailabilityTable")
     ];
     // Stryker restore all 
 

--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -67,12 +67,9 @@ export default function DriverAvailabilityTable({
         ButtonColumn("Delete", "danger", deleteCallback, "DriverAvailabilityTable")
     ];
 
-    const buttonColumnsAdmin = [
-        ...columns,
-    ];
     // Stryker restore all 
 
-    const columnsToDisplay = (hasRole(currentUser, "ROLE_ADMIN")) ? buttonColumnsAdmin : (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
+    const columnsToDisplay = (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
 
     return <OurTable
         data={Availability}

--- a/frontend/src/main/pages/DriverInfoPage.js
+++ b/frontend/src/main/pages/DriverInfoPage.js
@@ -3,10 +3,13 @@ import { useParams } from "react-router-dom";
 import { useBackend } from "main/utils/useBackend";
 import DriverInfo from "main/components/Driver/DriverInfo";
 import { Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
 
 export default function DriverInfoPage() {
     let { id } = useParams();
 
+    const navigate = useNavigate();
+    
     const { data: info, _error, _status } =
       useBackend(
         // Stryker disable next-line all : don't test internal caching of React Query
@@ -26,7 +29,7 @@ export default function DriverInfoPage() {
             return (
                 <Button
                     variant="primary"
-                    onClick={() => navigate(-1)}
+                    onClick={()=>{navigate(-1)}}
                 >
                     Return
                 </Button>

--- a/frontend/src/main/pages/DriverInfoPage.js
+++ b/frontend/src/main/pages/DriverInfoPage.js
@@ -26,7 +26,7 @@ export default function DriverInfoPage() {
             return (
                 <Button
                     variant="primary"
-                    href="/shift/"
+                    onClick={() => navigate(-1)}
                 >
                     Return
                 </Button>

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -5,11 +5,11 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { BrowserRouter as Router } from 'react-router-dom';
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-
+  
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate,
-}));
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate,
+  }));
 
 const mockedNavigate = jest.fn();
 
@@ -17,165 +17,165 @@ const expectedHeaders = ["Id", "Driver Id", "Day", "Start Time", "End Time", "No
 const expectedFields = ["id", "driverId", "day", "startTime", "endTime", "notes"];
 const testId = "DriverAvailabilityTable";
 describe("DriverAvailabilityTable tests", () => {
-  const queryClient = new QueryClient();
+    const queryClient = new QueryClient();
 
-  test("renders without crashing for empty table", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={[]} />
-        </Router>
-      </QueryClientProvider>
-    );
-  });
-
-  test("renders without crashing for three availabilities", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
-        </Router>
-      </QueryClientProvider>
-    );
-  });
-
-  test("Has the expected column headers and content", () => {
-    const { getByText, getByTestId } = render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
-        </Router>
-      </QueryClientProvider>
-    );
-
-
-    expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
-      expect(header).toBeInTheDocument();
+    test("renders without crashing for empty table", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <DriverAvailabilityTable Availability={[]} />
+                </Router>
+            </QueryClientProvider>
+        );
     });
 
-    expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(header).toBeInTheDocument();
+    test("renders without crashing for three availabilities", () => {
+      render(
+          <QueryClientProvider client={queryClient}>
+              <Router>
+                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
+              </Router>
+          </QueryClientProvider>
+      );
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-    expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-    expect(getByTestId(`${testId}-cell-row-0-col-startTime`)).toHaveTextContent("09:00AM");
-    expect(getByTestId(`${testId}-cell-row-0-col-endTime`)).toHaveTextContent("12:00PM");
-    expect(getByTestId(`${testId}-cell-row-0-col-notes`)).toHaveTextContent("has class from 8-9am");
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(getByTestId(`${testId}-cell-row-1-col-driverId`)).toHaveTextContent("5");
-    expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Thursday");
-    expect(getByTestId(`${testId}-cell-row-1-col-startTime`)).toHaveTextContent("11:00AM");
-    expect(getByTestId(`${testId}-cell-row-1-col-endTime`)).toHaveTextContent("01:45PM");
-    expect(getByTestId(`${testId}-cell-row-1-col-notes`)).toHaveTextContent("has class from 2-3pm");
-
-  });
-
-  test("Edit button navigates to the edit page", async () => {
-    const currentUser = currentUserFixtures.driverOnly;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
-    expect(editButton).toBeInTheDocument();
-
-    // act - click the edit button
-    fireEvent.click(editButton);
-
-    // assert - check that we navigated to the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/availability/edit/1'));
-  });
-
-  test("Delete button calls delete callback", async () => {
-    const currentUser = currentUserFixtures.driverOnly;
+    test("Has the expected column headers and content", () => {
+      const { getByText, getByTestId } = render(
+          <QueryClientProvider client={queryClient}>
+              <Router>
+                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
+              </Router>
+          </QueryClientProvider>
+      );
 
 
-    // act - render the component
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </Router>
-      </QueryClientProvider>
-    );
+      expectedHeaders.forEach( (headerText)=> {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+      });
 
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+      expectedFields.forEach( (field)=> {
+        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument(); 
+      });
 
-    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    expect(deleteButton).toBeInTheDocument();
+      expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      expect(getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+      expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
+      expect(getByTestId(`${testId}-cell-row-0-col-startTime`)).toHaveTextContent("09:00AM");
+      expect(getByTestId(`${testId}-cell-row-0-col-endTime`)).toHaveTextContent("12:00PM");
+      expect(getByTestId(`${testId}-cell-row-0-col-notes`)).toHaveTextContent("has class from 8-9am");
+      expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+      expect(getByTestId(`${testId}-cell-row-1-col-driverId`)).toHaveTextContent("5");
+      expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Thursday");
+      expect(getByTestId(`${testId}-cell-row-1-col-startTime`)).toHaveTextContent("11:00AM");
+      expect(getByTestId(`${testId}-cell-row-1-col-endTime`)).toHaveTextContent("01:45PM");
+      expect(getByTestId(`${testId}-cell-row-1-col-notes`)).toHaveTextContent("has class from 2-3pm");
 
-    // act - click the delete button
-    fireEvent.click(deleteButton);
-  });
-
-  test("Has the expected column headers and content for admin user", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </Router>
-      </QueryClientProvider>
-    );
-
-    expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
-      expect(header).toBeInTheDocument();
     });
 
-    expectedFields.forEach((field) => {
-      const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(cellContent).toBeInTheDocument();
+    test("Edit button navigates to the edit page", async () => {
+      const currentUser = currentUserFixtures.driverOnly;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert - check that the expected content is rendered
+      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+  
+      const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+      expect(editButton).toBeInTheDocument();
+  
+      // act - click the edit button
+      fireEvent.click(editButton);
+  
+      // assert - check that we navigated to the expected path
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/availability/edit/1'));
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-  });
-
-
-  test("Has the expected column headers, content, and buttons for ordinary user", () => {
-    const currentUser = currentUserFixtures.userOnly;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </Router>
-      </QueryClientProvider>
-    );
-
-    expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
-      expect(header).toBeInTheDocument();
+    test("Delete button calls delete callback", async () => {
+      const currentUser = currentUserFixtures.driverOnly;
+      
+      
+      // act - render the component
+      render(
+        <QueryClientProvider client={queryClient}>
+          <Router>
+            <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+          </Router>
+        </QueryClientProvider>
+      );
+    
+      // assert - check that the expected content is rendered
+      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+    
+      const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+      expect(deleteButton).toBeInTheDocument();
+    
+      // act - click the delete button
+      fireEvent.click(deleteButton);
     });
 
-    expectedFields.forEach((field) => {
-      const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(cellContent).toBeInTheDocument();
+    test("Has the expected column headers and content for admin user", () => {
+      const currentUser = currentUserFixtures.adminUser;
+        
+      render(
+          <QueryClientProvider client={queryClient}>
+              <Router>
+                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+              </Router>
+          </QueryClientProvider>
+      );
+  
+      expectedHeaders.forEach((headerText) => {
+          const header = screen.getByText(headerText);
+          expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+          const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(cellContent).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+  
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
 
-    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
-  });
-
+      test("Has the expected column headers, content, and buttons for ordinary user", () => {
+        const currentUser = currentUserFixtures.userOnly;
+        
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+                </Router>
+            </QueryClientProvider>
+        );
+    
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    
+        expectedFields.forEach((field) => {
+            const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(cellContent).toBeInTheDocument();
+        });
+    
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+    
+        expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+        expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+      
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -147,9 +147,6 @@ describe("DriverAvailabilityTable tests", () => {
       expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
   
-      const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-      expect(reviewButton).toBeInTheDocument();
-      expect(reviewButton).toHaveClass("btn-primary");
     });
 
 
@@ -181,52 +178,5 @@ describe("DriverAvailabilityTable tests", () => {
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();
     });
       
-      test("Review button triggers navigation", async () => {
-        const currentUser = currentUserFixtures.adminUser;
-      
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-            </MemoryRouter>
-          </QueryClientProvider>
-        );
-      
-        // assert - check that the expected content is rendered
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-        expect(editButton).toBeInTheDocument();
-      
-        // act - click the edit button
-        fireEvent.click(editButton);
-      
-        // assert - check if the mocked navigate function was called
-        expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1');
-      });
-      
-  test("Review button navigates to the edit page", async () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-    const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-    expect(reviewButton).toBeInTheDocument();
-
-    // act - click the edit button
-    fireEvent.click(reviewButton);
-
-    // assert - check that we navigated to the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1'));
-  });
 
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -5,11 +5,11 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { BrowserRouter as Router } from 'react-router-dom';
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-  
+
 jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockedNavigate,
-  }));
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}));
 
 const mockedNavigate = jest.fn();
 
@@ -17,166 +17,199 @@ const expectedHeaders = ["Id", "Driver Id", "Day", "Start Time", "End Time", "No
 const expectedFields = ["id", "driverId", "day", "startTime", "endTime", "notes"];
 const testId = "DriverAvailabilityTable";
 describe("DriverAvailabilityTable tests", () => {
-    const queryClient = new QueryClient();
+  const queryClient = new QueryClient();
 
-    test("renders without crashing for empty table", () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityTable Availability={[]} />
-                </Router>
-            </QueryClientProvider>
-        );
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={[]} />
+        </Router>
+      </QueryClientProvider>
+    );
+  });
+
+  test("renders without crashing for three availabilities", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
+        </Router>
+      </QueryClientProvider>
+    );
+  });
+
+  test("Has the expected column headers and content", () => {
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("renders without crashing for three availabilities", () => {
-      render(
-          <QueryClientProvider client={queryClient}>
-              <Router>
-                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
-              </Router>
-          </QueryClientProvider>
-      );
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Has the expected column headers and content", () => {
-      const { getByText, getByTestId } = render(
-          <QueryClientProvider client={queryClient}>
-              <Router>
-                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} />
-              </Router>
-          </QueryClientProvider>
-      );
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+    expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
+    expect(getByTestId(`${testId}-cell-row-0-col-startTime`)).toHaveTextContent("09:00AM");
+    expect(getByTestId(`${testId}-cell-row-0-col-endTime`)).toHaveTextContent("12:00PM");
+    expect(getByTestId(`${testId}-cell-row-0-col-notes`)).toHaveTextContent("has class from 8-9am");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(getByTestId(`${testId}-cell-row-1-col-driverId`)).toHaveTextContent("5");
+    expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Thursday");
+    expect(getByTestId(`${testId}-cell-row-1-col-startTime`)).toHaveTextContent("11:00AM");
+    expect(getByTestId(`${testId}-cell-row-1-col-endTime`)).toHaveTextContent("01:45PM");
+    expect(getByTestId(`${testId}-cell-row-1-col-notes`)).toHaveTextContent("has class from 2-3pm");
+
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.driverOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that we navigated to the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/availability/edit/1'));
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.driverOnly;
 
 
-      expectedHeaders.forEach( (headerText)=> {
-          const header = getByText(headerText);
-          expect(header).toBeInTheDocument();
-      });
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </Router>
+      </QueryClientProvider>
+    );
 
-      expectedFields.forEach( (field)=> {
-        const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-        expect(header).toBeInTheDocument(); 
-      });
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
 
-      expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-      expect(getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-      expect(getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-      expect(getByTestId(`${testId}-cell-row-0-col-startTime`)).toHaveTextContent("09:00AM");
-      expect(getByTestId(`${testId}-cell-row-0-col-endTime`)).toHaveTextContent("12:00PM");
-      expect(getByTestId(`${testId}-cell-row-0-col-notes`)).toHaveTextContent("has class from 8-9am");
-      expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-      expect(getByTestId(`${testId}-cell-row-1-col-driverId`)).toHaveTextContent("5");
-      expect(getByTestId(`${testId}-cell-row-1-col-day`)).toHaveTextContent("Thursday");
-      expect(getByTestId(`${testId}-cell-row-1-col-startTime`)).toHaveTextContent("11:00AM");
-      expect(getByTestId(`${testId}-cell-row-1-col-endTime`)).toHaveTextContent("01:45PM");
-      expect(getByTestId(`${testId}-cell-row-1-col-notes`)).toHaveTextContent("has class from 2-3pm");
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
 
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+
+  test("Has the expected column headers and content for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Edit button navigates to the edit page", async () => {
-      const currentUser = currentUserFixtures.driverOnly;
-  
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-          </MemoryRouter>
-        </QueryClientProvider>
-      );
-  
-      // assert - check that the expected content is rendered
-      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-  
-      const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
-      expect(editButton).toBeInTheDocument();
-  
-      // act - click the edit button
-      fireEvent.click(editButton);
-  
-      // assert - check that we navigated to the expected path
-      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/availability/edit/1'));
+    expectedFields.forEach((field) => {
+      const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cellContent).toBeInTheDocument();
     });
 
-    test("Delete button calls delete callback", async () => {
-      const currentUser = currentUserFixtures.driverOnly;
-      
-      
-      // act - render the component
-      render(
-        <QueryClientProvider client={queryClient}>
-          <Router>
-            <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-          </Router>
-        </QueryClientProvider>
-      );
-    
-      // assert - check that the expected content is rendered
-      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-    
-      const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-      expect(deleteButton).toBeInTheDocument();
-    
-      // act - click the delete button
-      fireEvent.click(deleteButton);
-    });
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
 
-    test("Has the expected column headers and content for admin user", () => {
-      const currentUser = currentUserFixtures.adminUser;
-        
-      render(
-          <QueryClientProvider client={queryClient}>
-              <Router>
-                  <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-              </Router>
-          </QueryClientProvider>
-      );
-  
-      expectedHeaders.forEach((headerText) => {
-          const header = screen.getByText(headerText);
-          expect(header).toBeInTheDocument();
-      });
-  
-      expectedFields.forEach((field) => {
-          const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-          expect(cellContent).toBeInTheDocument();
-      });
-  
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-  
-    });
+  });
 
 
-      test("Has the expected column headers, content, and buttons for ordinary user", () => {
-        const currentUser = currentUserFixtures.userOnly;
-        
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-                </Router>
-            </QueryClientProvider>
-        );
-    
-        expectedHeaders.forEach((headerText) => {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
-    
-        expectedFields.forEach((field) => {
-            const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-            expect(cellContent).toBeInTheDocument();
-        });
-    
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-    
-        expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-        expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  test("Has the expected column headers, content, and buttons for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
-      
+
+    expectedFields.forEach((field) => {
+      const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cellContent).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+
+  test("Admin view does not see review button", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+   
+  });
+
+  test("User view does not see review button", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
+
+  });
 
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -178,38 +178,4 @@ describe("DriverAvailabilityTable tests", () => {
     expect(screen.queryByText("Edit")).not.toBeInTheDocument();
   });
 
-
-  test("Admin view does not see review button", async () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-   
-  });
-
-  test("User view does not see review button", async () => {
-    const currentUser = currentUserFixtures.userOnly;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-  });
-
 });

--- a/frontend/src/tests/pages/DriverInfoPage.test.js
+++ b/frontend/src/tests/pages/DriverInfoPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
@@ -101,4 +101,21 @@ describe("DriverInfoPage tests", () => {
         });
 
     });
+
+    test("that return button is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.getByText("Return")).toBeInTheDocument();
+
+        const returnButton = screen.getByText("Return");
+
+        fireEvent.click(returnButton);
+    });
+
 });

--- a/frontend/src/tests/pages/DriverInfoPage.test.js
+++ b/frontend/src/tests/pages/DriverInfoPage.test.js
@@ -102,7 +102,7 @@ describe("DriverInfoPage tests", () => {
 
     });
 
-    test("that return button is clicked", async () => {
+    test("that return button is on screen", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -111,8 +111,10 @@ describe("DriverInfoPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.getByText("Return")).toBeInTheDocument();
-
+        await waitFor(() => {
+            expect(screen.getByText("Return")).toBeInTheDocument();
+        });
+       
         const returnButton = screen.getByText("Return");
 
         fireEvent.click(returnButton);


### PR DESCRIPTION
Made it so when you click on the driver id in DriverAvailabiltyIndexPage it takes you to the driver info page. Removed the return button from this page and made sure that all tests are passing for all driver pages. 

See how Driver id is a link now:
<img width="1359" alt="Screenshot 2024-05-21 at 6 14 28 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/23d8ce93-7727-4bd5-a5c2-8abb246493e0">

Link takes you to this page (return takes you back):
<img width="1286" alt="Screenshot 2024-05-21 at 6 15 01 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/6c63d777-8013-4ddf-b7a7-1a98aabf8eee">

Closes #5