### PR TITLE
Diya - fix labels for drivers form

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -31,14 +31,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                 </Form.Group>
             )}
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="driverId">driverId</Form.Label>
+                <Form.Label htmlFor="driverId">Driver Id</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-driverId"}
                     id="driverId"
                     type="text"
                     isInvalid={Boolean(errors.driverId)}
                     {...register("driverId", {
-                        required: "driverId is required.",
+                        required: "Driver Id is required.",
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -47,14 +47,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="day">day</Form.Label>
+                <Form.Label htmlFor="day">Day</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-day"}
                     id="day"
                     type="text"
                     isInvalid={Boolean(errors.day)}
                     {...register("day", {
-                        required: "day is required."
+                        required: "Day is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -63,14 +63,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="startTime">startTime</Form.Label>
+                <Form.Label htmlFor="startTime">Start Time</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-startTime"}
                     id="startTime"
                     type="text"
                     isInvalid={Boolean(errors.startTime)}
                     {...register("startTime", {
-                        required: "startTime is required."
+                        required: "Start Time is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -79,14 +79,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="endTime">endTime</Form.Label>
+                <Form.Label htmlFor="endTime">End Time</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-endTime"}
                     id="endTime"
                     type="text"
                     isInvalid={Boolean(errors.endTime)}
                     {...register("endTime", {
-                        required: "endTime is required."
+                        required: "End Time is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -95,14 +95,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">notes</Form.Label>
+                <Form.Label htmlFor="notes">Notes</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-notes"}
                     id="notes"
                     type="text"
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes", {
-                        required: "notes is required."
+                        required: "Notes is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("DriverAvailabilityForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["driverId", "day", "startTime", "endTime", "notes"];
+    const expectedHeaders = ["Driver Id", "Day", "Start Time", "End Time", "Notes"];
     const testId = "DriverAvailabilityForm";
 
     test("renders correctly with no initialContents", async () => {

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -57,19 +57,19 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.getByText(`id`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-driverId`)).toBeInTheDocument();
-        expect(screen.getByText(`driverId`)).toBeInTheDocument();
+        expect(screen.getByText("Driver Id")).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
-        expect(screen.getByText(`day`)).toBeInTheDocument();
+        expect(screen.getByText("Day")).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-startTime`)).toBeInTheDocument();
-        expect(screen.getByText(`startTime`)).toBeInTheDocument();
+        expect(screen.getByText("Start Time")).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-endTime`)).toBeInTheDocument();
-        expect(screen.getByText(`endTime`)).toBeInTheDocument();
+        expect(screen.getByText("End Time")).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-notes`)).toBeInTheDocument();
-        expect(screen.getByText(`notes`)).toBeInTheDocument();
+        expect(screen.getByText("Notes")).toBeInTheDocument();
     });
 
 
@@ -102,11 +102,11 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByText(/Create/);
         fireEvent.click(submitButton);
 
-        await screen.findByText(/driverId is required./);
-        expect(screen.getByText(/day is required./)).toBeInTheDocument();
-        expect(screen.getByText(/startTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/endTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/notes is required./)).toBeInTheDocument();
+        await screen.findByText(/Driver Id is required./);
+        expect(screen.getByText(/Day is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes is required./)).toBeInTheDocument();
 
     });
 
@@ -138,11 +138,11 @@ describe("DriverAvailabilityForm tests", () => {
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/driverId is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/day is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/startTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/endTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/notes is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Driver Id is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Start Time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/End Time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Notes is required./)).not.toBeInTheDocument();
 
 
     });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -82,21 +82,21 @@ describe("DriverAvailabilityCreatePage tests", () => {
         )
 
 
-        const driverIdInput = screen.getByLabelText("driverId")
+        const driverIdInput = screen.getByLabelText("Driver Id")
         await waitFor(() => {
             expect(driverIdInput).toBeInTheDocument();
         });
 
-        const dayInput = screen.getByLabelText("day");
+        const dayInput = screen.getByLabelText("Day");
         expect(dayInput).toBeInTheDocument();
 
-        const startTimeInput = screen.getByLabelText("startTime");
+        const startTimeInput = screen.getByLabelText("Start Time");
         expect(startTimeInput).toBeInTheDocument();
 
-        const endTimeInput = screen.getByLabelText("endTime");
+        const endTimeInput = screen.getByLabelText("End Time");
         expect(endTimeInput).toBeInTheDocument();
 
-        const notesInput = screen.getByLabelText("notes");
+        const notesInput = screen.getByLabelText("Notes");
         expect(notesInput).toBeInTheDocument();
 
         // Simulating filling out the form


### PR DESCRIPTION
This is part of an EPIC for DriverAvailabilities. For this part, I am updating the frontend form to have clear labels. 

Before:
<img width="352" alt="Screenshot 2024-05-21 at 8 22 32 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/d1a94346-9cce-43a4-8110-8bbbdff4e262">

After: 
<img width="466" alt="Screenshot 2024-05-21 at 8 22 16 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/65d89dc8-a2ba-4824-b3b0-6a0645dcfd1c">


Closes #30 