### PR TITLE
Yuji - Dropdown for DriverID in create shifts

### DIFF
--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -124,6 +124,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                         required: "Driver ID is required."
                     })}
                 >
+                    <option value="">Select a driver</option>
                     {drivers && drivers.map(driver => (
                         <option key={driver.id} value={driver.id}>
                             {driver.id + " - " + driver.fullName}
@@ -148,6 +149,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                         required: "Driver Backup ID is required."
                     })}
                 >
+                    <option value="">Select a driver</option>
                     {drivers && drivers.map(driver => (
                         <option key={driver.id} value={driver.id}>
                             {driver.id + " - " + driver.fullName}

--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -9,7 +9,6 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         register,
         formState: { errors },
         handleSubmit,
-        watch,
     } = useForm({ defaultValues: initialContents || {} });
     // Stryker restore all
     const navigate = useNavigate();
@@ -23,14 +22,6 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             []
             // Stryker restore all 
         );
-    
-    const selectedMainDriver = watch("driverID");
-    const validateBackupDriver = (value) => {
-        if (value === selectedMainDriver) {
-            return "Backup driver cannot be the same as the main driver.";
-        }
-        return true;
-    };
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -156,7 +147,6 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     isInvalid={Boolean(errors.driverBackupID)}
                     {...register("driverBackupID", {
                         required: "Driver Backup ID is required.",
-                        validate: validateBackupDriver
                     })}
                 >
                     <option value="">Select a driver</option>

--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -1,6 +1,7 @@
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { useBackend } from 'main/utils/useBackend';
 
 function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     // Stryker disable all
@@ -12,6 +13,15 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     // Stryker restore all
     const navigate = useNavigate();
     const testIdPrefix = "ShiftForm";
+
+    const { data: drivers, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable all : hard to test for query caching
+            ["/api/drivers/all"],
+            { method: "GET", url: "/api/drivers/all" },
+            []
+            // Stryker restore all 
+        );
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -107,12 +117,19 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     data-testid={testIdPrefix + "-driverID"}
                     id="driverID"
                     name="driverID"
-                    type="number"
+                    as="select"
+                    type="select"
                     isInvalid={Boolean(errors.driverID)}
                     {...register("driverID", {
                         required: "Driver ID is required."
                     })}
-                />
+                >
+                    {drivers && drivers.map(driver => (
+                        <option key={driver.id} value={driver.id}>
+                            {driver.id + " - " + driver.fullName}
+                        </option>
+                    ))}
+                </Form.Control>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverID?.message}
                 </Form.Control.Feedback>
@@ -124,12 +141,19 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     data-testid={testIdPrefix + "-driverBackupID"}
                     id="driverBackupID"
                     name="driverBackupID"
-                    type="number"
+                    as="select"
+                    type="select"
                     isInvalid={Boolean(errors.driverBackupID)}
                     {...register("driverBackupID", {
                         required: "Driver Backup ID is required."
                     })}
-                />
+                >
+                    {drivers && drivers.map(driver => (
+                        <option key={driver.id} value={driver.id}>
+                            {driver.id + " - " + driver.fullName}
+                        </option>
+                    ))}
+                </Form.Control>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverBackupID?.message}
                 </Form.Control.Feedback>

--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -9,6 +9,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         register,
         formState: { errors },
         handleSubmit,
+        watch,
     } = useForm({ defaultValues: initialContents || {} });
     // Stryker restore all
     const navigate = useNavigate();
@@ -22,6 +23,14 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             []
             // Stryker restore all 
         );
+    
+    const selectedMainDriver = watch("driverID");
+    const validateBackupDriver = (value) => {
+        if (value === selectedMainDriver) {
+            return "Backup driver cannot be the same as the main driver.";
+        }
+        return true;
+    };
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -43,7 +52,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="day">Day of the Week</Form.Label>
-                <Form.Control 
+                <Form.Select 
                     as="select"
                     data-testid={testIdPrefix + "-day"}
                     id="day"
@@ -61,7 +70,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     <option value="Friday">Friday</option>
                     <option value="Saturday">Saturday</option>
                     <option value="Sunday">Sunday</option>
-                </Form.Control>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                     {errors.day?.message}
                 </Form.Control.Feedback>
@@ -113,7 +122,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverID">Driver ID</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-driverID"}
                     id="driverID"
                     name="driverID"
@@ -130,7 +139,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                             {driver.id + " - " + driver.fullName}
                         </option>
                     ))}
-                </Form.Control>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverID?.message}
                 </Form.Control.Feedback>
@@ -138,7 +147,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverBackupID">Driver Backup ID</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-driverBackupID"}
                     id="driverBackupID"
                     name="driverBackupID"
@@ -146,7 +155,8 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     type="select"
                     isInvalid={Boolean(errors.driverBackupID)}
                     {...register("driverBackupID", {
-                        required: "Driver Backup ID is required."
+                        required: "Driver Backup ID is required.",
+                        validate: validateBackupDriver
                     })}
                 >
                     <option value="">Select a driver</option>
@@ -155,7 +165,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                             {driver.id + " - " + driver.fullName}
                         </option>
                     ))}
-                </Form.Control>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverBackupID?.message}
                 </Form.Control.Feedback>

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -122,36 +122,6 @@ describe("ShiftForm tests", () => {
         expect(screen.getByTestId("ShiftForm-submit")).toBeInTheDocument();
     });
 
-    test("validates that backup driver cannot be the same as the main driver", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <ShiftForm />
-                </Router>
-            </QueryClientProvider>
-        );
-    
-        // Select the same driver for both driverID and driverBackupID
-        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
-        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "1" } });
-    
-        // Try to submit the form
-        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
-    
-        // Check for the validation message
-        await waitFor(() => expect(screen.getByText("Backup driver cannot be the same as the main driver.")).toBeInTheDocument());
-    
-        // Select different drivers for driverID and driverBackupID
-        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
-        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "2" } });
-    
-        // Try to submit the form again
-        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
-    
-        // Check that the validation message is not present
-        await waitFor(() => expect(screen.queryByText("Backup driver cannot be the same as the main driver.")).not.toBeInTheDocument());
-    });
-
     test("validates time format", async () => {
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -3,6 +3,9 @@ import { BrowserRouter as Router } from "react-router-dom";
 
 import ShiftForm from "main/components/Shift/ShiftForm";
 import { shiftFixtures } from "fixtures/shiftFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import driverFixtures from "fixtures/driverFixtures";
 
 import { QueryClient, QueryClientProvider } from "react-query";
 
@@ -18,6 +21,13 @@ describe("ShiftForm tests", () => {
 
     const expectedHeaders = ["Day of the Week", "Shift Start","Shift End","Driver ID","Driver Backup ID"];
     const testId = "ShiftForm";
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
+    });
 
     test("renders correctly with no initialContents", async () => {
         render(
@@ -110,6 +120,36 @@ describe("ShiftForm tests", () => {
         expect(screen.getByTestId("ShiftForm-driverID")).toBeInTheDocument();
         expect(screen.getByTestId("ShiftForm-driverBackupID")).toBeInTheDocument();
         expect(screen.getByTestId("ShiftForm-submit")).toBeInTheDocument();
+    });
+
+    test("validates that backup driver cannot be the same as the main driver", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ShiftForm />
+                </Router>
+            </QueryClientProvider>
+        );
+    
+        // Select the same driver for both driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
+        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "1" } });
+    
+        // Try to submit the form
+        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
+    
+        // Check for the validation message
+        await waitFor(() => expect(screen.getByText("Backup driver cannot be the same as the main driver.")).toBeInTheDocument());
+    
+        // Select different drivers for driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
+        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "2" } });
+    
+        // Try to submit the form again
+        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
+    
+        // Check that the validation message is not present
+        await waitFor(() => expect(screen.queryByText("Backup driver cannot be the same as the main driver.")).not.toBeInTheDocument());
     });
 
     test("validates time format", async () => {

--- a/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
@@ -8,6 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import driverFixtures from "fixtures/driverFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -39,6 +40,7 @@ describe("ShiftCreatePage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
     });
 
     const queryClient = new QueryClient();

--- a/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
@@ -9,6 +9,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import mockConsole from "jest-mock-console";
+import driverFixtures from "fixtures/driverFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -44,6 +45,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).timeout();
         });
 
@@ -74,6 +76,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 day: "Tuesday",
@@ -125,8 +128,8 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
         });
 
         test("Changes when you click Update", async () => {
@@ -152,8 +155,8 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
 
             expect(submitButton).toBeInTheDocument();
         

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
@@ -81,14 +81,14 @@ public class ShiftController extends ApiController {
         @Parameter(name="day") @RequestParam String day,
         @Parameter(name="shiftStart") @RequestParam String shiftStart,
         @Parameter(name="shiftEnd") @RequestParam String shiftEnd,
-        @Parameter(name="driverID") @RequestParam long driverID ,
+        @Parameter(name="driverID") @RequestParam long driverID,
         @Parameter(name="driverBackupID") @RequestParam long driverBackupID
         )
         {
 
         Shift shift = new Shift();
 
-        shift.setDriverID(getCurrentUser().getUser().getId());
+        shift.setDriverID(driverID);
         shift.setDay(day);
         shift.setShiftStart(shiftStart);
         shift.setShiftEnd(shiftEnd);


### PR DESCRIPTION
### Issue to fix
Currently have to manually check and search for Driver ID's when creating a new shift as admin.

### Changes for Create Shift
Added a dropdown for DriverID and Backup Driver ID in create shifts so an admin can easily select from a dropdown containing all of the drivers.
Added a "Select a driver" placeholder for the dropdown.
Changed Form.Control to Form.Select to appropriately handle dropdown menu options.
Added useBackend in shiftForm, and changed ShiftForm, ShiftEditPage, ShiftCreatePage tests.
Ensured that the admin user is not automatically assigned as the primary driver in ShiftController.java. 
No need to manually check and search for Driver ID's now. Dropdown will give all existing Driver ID's.

Dokku Deployment: https://proj-gauchoride-yuji-sakaguchi-dev.dokku-14.cs.ucsb.edu/

Please also review https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/pull/47 since I found additional bugs

Closes #12 

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/c0be3f98-95aa-4c88-9111-03604a105a11)