### PR TITLE
Diya - Updating Driver Availability Form Frontend with error messages and placeholder values 

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -40,6 +40,8 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("driverId", {
                         required: "driverId is required.",
                     })}
+                    placeholder="Enter a valid ID"   
+                    defaultValue={initialContents?.driverId}  
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.driverId?.message}
@@ -48,7 +50,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="day">day</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-day"}
                     id="day"
                     type="text"
@@ -56,7 +58,16 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("day", {
                         required: "day is required."
                     })}
-                />
+                    >
+                    <option value="">Select a Day</option>
+                    <option value="Monday">Monday</option>
+                    <option value="Tuesday">Tuesday</option>
+                    <option value="Wednesday">Wednesday</option>
+                    <option value="Thursday">Thursday</option>
+                    <option value="Friday">Friday</option>
+                    <option value="Saturday">Saturday</option>
+                    <option value="Sunday">Sunday</option>
+                    </Form.Select>
                 <Form.Control.Feedback type="invalid">
                     {errors.day?.message}
                 </Form.Control.Feedback>
@@ -70,8 +81,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     type="text"
                     isInvalid={Boolean(errors.startTime)}
                     {...register("startTime", {
-                        required: "startTime is required."
+                        required: "startTime is required.",
+                        pattern: {
+                            value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
+                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                          }
                     })}
+                    placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"   
+                    defaultValue={initialContents?.startTime}   
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.startTime?.message}
@@ -86,8 +103,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     type="text"
                     isInvalid={Boolean(errors.endTime)}
                     {...register("endTime", {
-                        required: "endTime is required."
+                        required: "endTime is required.",
+                        pattern: {
+                            value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
+                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                          }
                     })}
+                    placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"   
+                    defaultValue={initialContents?.endTime}   
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.endTime?.message}
@@ -104,6 +127,8 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("notes", {
                         required: "notes is required."
                     })}
+                    placeholder="Enter some text for notes"   
+                    defaultValue={initialContents?.notes}  
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.notes?.message}

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -40,7 +40,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("driverId", {
                         required: "driverId is required.",
                     })}
-                    placeholder="Enter a valid ID"   
+                    placeholder="e.g. 1"   
                     defaultValue={initialContents?.driverId}  
                 />
                 <Form.Control.Feedback type="invalid">
@@ -127,7 +127,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("notes", {
                         required: "notes is required."
                     })}
-                    placeholder="Enter some text for notes"   
+                    placeholder="e.g. I am mostly available on Tuesday and Thursdays."  
                     defaultValue={initialContents?.notes}  
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -146,4 +146,34 @@ describe("DriverAvailabilityForm tests", () => {
 
 
     });
+
+
+    test("Error messsages on bad input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <DriverAvailabilityForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("DriverAvailabilityForm-driverId");
+
+        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        fireEvent.change(driverIdField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
+        fireEvent.change(startTimeField, { target: { value: '315PM' } });
+        fireEvent.change(endTimeField, { target: { value: '4:15PM' } });
+        fireEvent.change(notesField, { target: { value: 'test' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(screen.getByText("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument());
+    });
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -143,8 +143,7 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/Start Time is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/End Time is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Notes is required./)).not.toBeInTheDocument();
-
-
+        expect(screen.queryByText("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).")).not.toBeInTheDocument();
     });
 
 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -146,36 +146,4 @@ describe("DriverAvailabilityForm tests", () => {
 
 
     });
-
-
-    test("Error message on bad input", async () => {
-
-        const mockSubmitAction = jest.fn();
-
-
-        render(
-            <Router  >
-                <DriverAvailabilityForm submitAction={mockSubmitAction} />
-            </Router>
-        );
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
-
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
-        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
-        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
-        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
-        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
-        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
-
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
-        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
-        fireEvent.change(startTimeField, { target: { value: 'Five past three' } });
-        fireEvent.change(endTimeField, { target: { value: 'Five past four' } });
-        fireEvent.change(notesField, { target: { value: 'test' } });
-        fireEvent.click(submitButton);
-
-        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
-
-        expect(screen.queryByText("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
-    });
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -147,10 +147,9 @@ describe("DriverAvailabilityForm tests", () => {
     });
 
 
-    test("Error messsages on bad input", async () => {
+    test("Error messages on missing inputs", async () => {
 
         const mockSubmitAction = jest.fn();
-
 
         render(
             <Router  >
@@ -166,6 +165,41 @@ describe("DriverAvailabilityForm tests", () => {
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
+        fireEvent.change(driverIdField, { target: { value: '' } });
+        fireEvent.change(dayField, { target: { value: '' } });
+        fireEvent.change(startTimeField, { target: { value: '' } });
+        fireEvent.change(endTimeField, { target: { value: '' } });
+        fireEvent.change(notesField, { target: { value: '' } });
+        fireEvent.click(submitButton);
+
+        expect(await screen.findByText(/Driver Id is required./)).toBeInTheDocument();
+        expect(screen.queryByText(/Day is required./)).toBeInTheDocument();
+        expect(screen.queryByText(/Start Time is required./)).toBeInTheDocument();
+        expect(screen.queryByText(/End Time is required./)).toBeInTheDocument();
+        expect(screen.queryByText(/Notes is required./)).toBeInTheDocument();
+
+    });
+
+   
+    test("Error messages on bad time format", async () => {
+        const mockSubmitAction = jest.fn();
+
+        render(
+            <Router>
+                <DriverAvailabilityForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+
+        await screen.findByTestId("DriverAvailabilityForm-driverId");
+
+        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        // Invalid start time format
         fireEvent.change(driverIdField, { target: { value: 'test' } });
         fireEvent.change(dayField, { target: { value: 'Tuesday' } });
         fireEvent.change(startTimeField, { target: { value: '315PM' } });
@@ -173,6 +207,76 @@ describe("DriverAvailabilityForm tests", () => {
         fireEvent.change(notesField, { target: { value: 'test' } });
         fireEvent.click(submitButton);
 
-        await waitFor(() => expect(screen.getByText("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument());
+        await waitFor(() => {
+            const startTimeError = screen.getByTestId("DriverAvailabilityForm-startTime").parentElement.querySelector('.invalid-feedback');
+            expect(startTimeError).toHaveTextContent("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).");
+        });
+    });
+
+    test("Error messages on bad time format - extra characters at beginning", async () => {
+        const mockSubmitAction = jest.fn();
+
+        render(
+            <Router>
+                <DriverAvailabilityForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+
+        await screen.findByTestId("DriverAvailabilityForm-driverId");
+
+        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        // Invalid start time format
+        fireEvent.change(driverIdField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
+        fireEvent.change(startTimeField, { target: { value: 'a3:15PM' } });
+        fireEvent.change(endTimeField, { target: { value: 'a4:15PM' } });
+        fireEvent.change(notesField, { target: { value: 'test' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            const startTimeError = screen.getByTestId("DriverAvailabilityForm-startTime").parentElement.querySelector('.invalid-feedback');
+            const endTimeError = screen.getByTestId("DriverAvailabilityForm-endTime").parentElement.querySelector('.invalid-feedback');
+            expect(startTimeError).toHaveTextContent("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).");
+            expect(endTimeError).toHaveTextContent("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).");
+        });
+    });
+
+    test("Error messages on bad time format - extra characters at end", async () => {
+        const mockSubmitAction = jest.fn();
+
+        render(
+            <Router>
+                <DriverAvailabilityForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+
+        await screen.findByTestId("DriverAvailabilityForm-driverId");
+
+        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        fireEvent.change(driverIdField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
+        fireEvent.change(startTimeField, { target: { value: '3:15PMa' } });
+        fireEvent.change(endTimeField, { target: { value: '4:15PMa' } });
+        fireEvent.change(notesField, { target: { value: 'test' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            const startTimeError = screen.getByTestId("DriverAvailabilityForm-startTime").parentElement.querySelector('.invalid-feedback');
+            const endTimeError = screen.getByTestId("DriverAvailabilityForm-endTime").parentElement.querySelector('.invalid-feedback');
+            expect(startTimeError).toHaveTextContent("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).");
+            expect(endTimeError).toHaveTextContent("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).");
+        });
     });
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -130,9 +130,9 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
         fireEvent.change(driverIdField, { target: { value: 'test' } });
-        fireEvent.change(dayField, { target: { value: 'test' } });
-        fireEvent.change(startTimeField, { target: { value: 'test' } });
-        fireEvent.change(endTimeField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
+        fireEvent.change(startTimeField, { target: { value: '3:15PM' } });
+        fireEvent.change(endTimeField, { target: { value: '4:15PM' } });
         fireEvent.change(notesField, { target: { value: 'test' } });
         fireEvent.click(submitButton);
 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -147,4 +147,35 @@ describe("DriverAvailabilityForm tests", () => {
 
     });
 
+
+    test("Error message on bad input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <DriverAvailabilityForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("DriverAvailabilityForm-driverId");
+
+        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        fireEvent.change(driverIdField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Tuesday' } });
+        fireEvent.change(startTimeField, { target: { value: 'Five past three' } });
+        fireEvent.change(endTimeField, { target: { value: 'Five past four' } });
+        fireEvent.change(notesField, { target: { value: 'test' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText("Please enter time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
EPIC: Updating the Drivers Availability Page 

As part of this EPIC we broke this large issue into three parts. We have two frontend PRs that have to change the Drivers Availability Page form. The last part of this EPIC will be updating the backend for this page. This PR addresses the second frontend issue. 

Before the Drivers Availability has no 'bad-input' error messages if the user does not input the correct information they are still able to submit the form. 

Here is the before: 
![image](https://github.com/ucsb-cs156/proj-gauchoride/assets/56096744/6a0b28e6-8e93-4763-a44f-59ce76db184e)

Now there is an actual error message that does not let the user input an invalid form. The day field is a drop-down where you can select a day of the week. The start time and end time have to have the correct format or the form will not be able to submit. 

Correct Error Message: 
<img width="537" alt="Screenshot 2024-05-22 at 5 59 03 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/ddf20aef-5bfe-405f-9363-aa64fd1288e6">

Before there were also no placeholder values in each field. The EPIC requirement asked to add placeholders to the field and you can see the changed here.

Placeholders: 
<img width="600" alt="Screenshot 2024-05-22 at 5 59 17 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/72777523/e472631d-2a8a-4788-8662-5d15138cfebb">

Deployment Link:  https://proj-gauchoride-s24-5pm-6-diyaparm.dokku-14.cs.ucsb.edu

How to Test:
- Try to submit a form with invalid times and you should receive an error message 
- Check to see if you see some placeholder values for each field 
- Check to see if the day is a drop-down value now 

Closes #31