### PR TITLE
Wesley - Expose commit info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -15,13 +16,11 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+# This approach (copying entire directory including git info) 
+# relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,17 +1,11 @@
 const systemInfoFixtures = {
     showingBoth: {
       springH2ConsoleEnabled: true,
-      showSwaggerUILink: true,
-      startQtrYYYYQ: "20084",
-      endQtrYYYYQ: "20222",
-      sourceRepo: "mocklink",
+      showSwaggerUILink: true
     },
     showingNeither: {
       springH2ConsoleEnabled: false,
-      showSwaggerUILink: false,
-      startQtrYYYYQ: "20084",
-      endQtrYYYYQ: "20222",
-      sourceRepo: "mocklink",
+      showSwaggerUILink: false
     },
   };
   

--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,16 +1,18 @@
 const systemInfoFixtures = {
-    showingBoth:
-    {
-        "springH2ConsoleEnabled": true,
-        "showSwaggerUILink": true
+    showingBoth: {
+      springH2ConsoleEnabled: true,
+      showSwaggerUILink: true,
+      startQtrYYYYQ: "20084",
+      endQtrYYYYQ: "20222",
+      sourceRepo: "mocklink",
     },
-    showingNeither:
-    {
-        "springH2ConsoleEnabled": false,
-        "showSwaggerUILink": false
-    }
-};
-
-
-
+    showingNeither: {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
+      startQtrYYYYQ: "20084",
+      endQtrYYYYQ: "20222",
+      sourceRepo: "mocklink",
+    },
+  };
+  
 export { systemInfoFixtures };

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -2,24 +2,30 @@ import { useQuery } from "react-query";
 import axios from "axios";
 
 export function useSystemInfo() {
-  
-  return useQuery("systemInfo", async () => {
-    try {
-      const response = await axios.get("/api/systemInfo");
-      return response.data;
-    } catch (e) {
-      console.error("Error invoking axios.get: ", e);
-      return {  
+  return useQuery(
+    "systemInfo",
+    async () => {
+      try {
+        const response = await axios.get("/api/systemInfo");
+        return response.data;
+      } catch (e) {
+        console.error("Error invoking axios.get: ", e);
+        return {
+          springH2ConsoleEnabled: false,
+          showSwaggerUILink: false,
+          startQtrYYYYQ: "20221",
+          endQtrYYYYQ: "20222",
+        };
+      }
+    },
+    {
+      initialData: {
+        initialData: true,
         springH2ConsoleEnabled: false,
-        showSwaggerUILink: false  
-      };
-    }
-  }, {
-    initialData: { 
-      initialData:true, 
-      springH2ConsoleEnabled: false,
-      showSwaggerUILink: false 
-    }
-  });
-
+        showSwaggerUILink: false,
+        startQtrYYYYQ: "20221",
+        endQtrYYYYQ: "20222",
+      },
+    },
+  );
 }

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -12,9 +12,7 @@ export function useSystemInfo() {
         console.error("Error invoking axios.get: ", e);
         return {
           springH2ConsoleEnabled: false,
-          showSwaggerUILink: false,
-          startQtrYYYYQ: "20221",
-          endQtrYYYYQ: "20222",
+          showSwaggerUILink: false
         };
       }
     },
@@ -22,9 +20,7 @@ export function useSystemInfo() {
       initialData: {
         initialData: true,
         springH2ConsoleEnabled: false,
-        showSwaggerUILink: false,
-        startQtrYYYYQ: "20221",
-        endQtrYYYYQ: "20222",
+        showSwaggerUILink: false
       },
     },
   );

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -32,7 +32,7 @@ describe("utils/systemInfo tests", () => {
             expect(result.current.data).toEqual({ 
                 initialData:true,   
                 springH2ConsoleEnabled: false,
-                showSwaggerUILink: false  
+                showSwaggerUILink: false
             });
             
             const queryState = queryClient.getQueryState("systemInfo");
@@ -91,7 +91,7 @@ describe("utils/systemInfo tests", () => {
 
             expect(result.current.data).toEqual({  
                 springH2ConsoleEnabled: false,
-                showSwaggerUILink: false 
+                showSwaggerUILink: false
             });
             queryClient.clear();
         });

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,30 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
 
         </plugins>
 
@@ -277,30 +301,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>io.github.git-commit-id</groupId>
-                        <artifactId>git-commit-id-maven-plugin</artifactId>
-                        <version>8.0.2</version>
-                        <executions>
-                            <execution>
-                                <id>get-the-git-infos</id>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                                <phase>initialize</phase>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <includeOnlyProperties>
-                                <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
-                                <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
-                                <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
-                            </includeOnlyProperties>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                            <commitIdGenerationMode>full</commitIdGenerationMode>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,25 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>io.github.git-commit-id</groupId>
+                        <artifactId>git-commit-id-maven-plugin</artifactId>
+                        <version>8.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                            <commitIdGenerationMode>full</commitIdGenerationMode>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,11 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <includeOnlyProperties>
+                                <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                                <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                                <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                            </includeOnlyProperties>
                             <generateGitPropertiesFile>true</generateGitPropertiesFile>
                             <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                             <commitIdGenerationMode>full</commitIdGenerationMode>

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -14,4 +14,10 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
+  private String startQtrYYYYQ;
+  private String endQtrYYYYQ;
+  private String sourceRepo; // user configured URL of the source repository for footer
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -14,6 +14,9 @@ import edu.ucsb.cs156.gauchoride.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+        @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 
 import edu.ucsb.cs156.gauchoride.models.SystemInfo;
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -27,10 +27,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.startQtrYYYYQ:20221}")
+  @Value("${app.startQtrYYYYQ:20242}")
   private String startQtrYYYYQ;
 
-  @Value("${app.endQtrYYYYQ:20222}")
+  @Value("${app.endQtrYYYYQ:20243}")
   private String endQtrYYYYQ;
 
   @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-6}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -33,7 +33,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.endQtrYYYYQ:20243}")
   private String endQtrYYYYQ;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-6}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,13 +22,39 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.startQtrYYYYQ:20221}")
+  private String startQtrYYYYQ;
+
+  @Value("${app.endQtrYYYYQ:20222}")
+  private String endQtrYYYYQ;
+
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-6}")
+  private String sourceRepo;
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
   public SystemInfo getSystemInfo() {
-    SystemInfo si = SystemInfo.builder()
-    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-    .showSwaggerUILink(this.showSwaggerUILink)
-    .build();
-  log.info("getSystemInfo returns {}",si);
-  return si;
+    SystemInfo si =
+        SystemInfo.builder()
+            .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+            .showSwaggerUILink(this.showSwaggerUILink)
+            .startQtrYYYYQ(this.startQtrYYYYQ)
+            .endQtrYYYYQ(this.endQtrYYYYQ)
+            .sourceRepo(this.sourceRepo)
+            .commitMessage(this.commitMessage)
+            .commitId(this.commitId)
+            .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+            .build();
+    log.info("getSystemInfo returns {}", si);
+    return si;
   }
 
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -33,7 +33,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.endQtrYYYYQ:20243}")
   private String endQtrYYYYQ;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-6}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.gauchoride.services;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -34,6 +36,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 
 }


### PR DESCRIPTION
Closes #13 

Added changes to the pom.xml, Dockerfile, and SystemInfo impl to allow for retrieving recent commit information through /api/systemInfo.

Admins can navigate to /api/systemInfo to find information about the most recent commit to the repository.

Steps to verify:
1. Log in at [Dev deployment](https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/) as an admin user
2. Navigate to /api/systemInfo
3. Verify that recent commit info appears as in below screenshot

Image:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/55602614/9a47535f-b5e6-4e26-96d0-630122b38c8e)

On a dokku deployment, the following commands need to be run first:
```
dokku git:set [app-name] keep-git-dir true
dokku config:set [app-name] SOURCE_REPO=https://ucsb-cs156-s24/proj-gauchoride-s24-5pm-6
```

[Dev deployment](https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/)

Tests: Passing