### PR TITLE
Lindsey - Fixed rider application bug

### DIFF
--- a/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationEditPageAdmin.js
@@ -7,15 +7,15 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
 export default function RiderApplicationEditPage() {
-  let { id } = useParams();
+  let { id, status, notes} = useParams();
 
-  const { data: riderApplication, _error, _status } =
+  const { data: riderApplication, error: _error, status: _status } =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/riderApplication?id=${id}`],
+      [`/api/rider/admin?id=${id}`],
       {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
         method: "GET",
-        url: `/api/riderApplication`,
+        url: `/api/rider/admin`,
         params: {
           id
         }
@@ -24,16 +24,16 @@ export default function RiderApplicationEditPage() {
 
 
   const objectToAxiosPutParams = (riderApplication) => ({
-    url: "/api/riderApplication",
+    url: "/api/rider/admin",
     method: "PUT",
     params: {
       id: riderApplication.id,
+      notes: riderApplication.notes,
+      status: riderApplication.status,
     },
     data: {
         perm_number: riderApplication.perm_number,
         description: riderApplication.description,
-        notes: riderApplication.notes,
-        status: riderApplication.status,
     }
   });
 
@@ -45,7 +45,7 @@ export default function RiderApplicationEditPage() {
     objectToAxiosPutParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [`/api/riderApplication?id=${id}`]
+    [`/api/rider/admin?id=${id}&status=${status}&notes=${notes}`]
   );
 
   const { isSuccess } = mutation

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -14,8 +14,8 @@ export default function RiderApplicationIndexPage() {
     const { data: riderApplications, error: _error, status: _status } =
         useBackend(
             // Stryker disable all : hard to test for query caching
-            ["/api/rider"],
-            { method: "GET", url: "/api/rider" },
+            ["/api/rider/admin/all"],
+            { method: "GET", url: "/api/rider/admin/all" },
             []
             // Stryker restore all 
     ); 

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationEditPageAdmin.test.js
@@ -74,7 +74,7 @@ describe("RiderApplicationEditPageAdmin tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-            axiosMock.onGet("/api/riderApplication", { params: { id: 17 } }).reply(200, {
+            axiosMock.onGet("/api/rider/admin", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 perm_number: "1234567",
                 status: "pending",
@@ -85,7 +85,7 @@ describe("RiderApplicationEditPageAdmin tests", () => {
                 description: "",
                 notes: ""
             });
-            axiosMock.onPut('/api/riderApplication').reply(200, {
+            axiosMock.onPut('/api/rider/admin').reply(200, {
                 id: 17,
                 perm_number: "7654321",
                 status: "pending",
@@ -186,12 +186,10 @@ describe("RiderApplicationEditPageAdmin tests", () => {
             expect(mockNavigate).toBeCalledWith({ "to": "/admin/applications/riders" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17, status: "pending", notes: "approving"});
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
                 perm_number: "1234567",
                 description: "",
-                notes: "approving",
-                status: "pending",
             })); // posted object
 
         });

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -74,7 +74,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders three rides without crashing for regular user", async () => {
         setupMemberOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, riderApplicationFixtures.threeRiderApplications);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -93,7 +93,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders three rides without crashing for admin user", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, riderApplicationFixtures.threeRiderApplications);
 
         render(
             <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
- Fixed bug in rider applications where an admin could not see any rider applications created by other users due to incorrect API calls (called regular user API rather than admin API)
- https://project-lindseywn.dokku-14.cs.ucsb.edu/

To recreate:
- Log in to admin account and go to Rider Applications
- You should be able to see applications from other email accounts 
- To further test, approve an existing pending application and see it move down to All Applications and say Status: accepted
- May not have the automatically toggle on application acceptance feature yet since I did on a different branch from main.
- Must use ucsb accounts

Created rider application with different account (temporarily used gmail account for testing purposes but please use ucsb)
<img width="1289" alt="Screen Shot 2024-05-26 at 12 36 06 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/43ca9bad-2c89-4ee1-b41c-83e378ec3b11">
<img width="1273" alt="Screen Shot 2024-05-26 at 12 36 59 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/57788b5b-1b7e-449b-b39d-7fc69b1e964c">

Now logged into admin account, application from other account shows up
<img width="1276" alt="Screen Shot 2024-05-26 at 12 42 07 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/e7ecb234-8a46-432c-b344-1e6fd559bdd6">

Approved application from admin acc
<img width="1241" alt="Screen Shot 2024-05-26 at 12 42 49 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/e96223e1-8305-401d-9ebc-5754894d9e2b">

Accepted status reflects in other account (still shows Apply to Be a Rider on navbar because role didn't change, that was done in other PR where rider role is auto toggled at acceptance)
<img width="1275" alt="Screen Shot 2024-05-26 at 12 43 27 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/be3dd11c-bf1c-43f6-8733-9672bc0726b4">

Closes #41 