### PR TITLE
Yuji - Fixed Stryker Typos

### DIFF
--- a/frontend/src/main/components/ChatMessage/ChatMessageForm.js
+++ b/frontend/src/main/components/ChatMessage/ChatMessageForm.js
@@ -16,7 +16,7 @@ function ChatMessageForm({ initialContents, submitAction, buttonLabel = "Send" }
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "ChatMessageForm";
 

--- a/frontend/src/main/components/Ride/RideAssignDriverForm.js
+++ b/frontend/src/main/components/Ride/RideAssignDriverForm.js
@@ -16,7 +16,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "RideAssignDriverForm";
 

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -16,7 +16,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "RideForm";
 

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -15,7 +15,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "RiderApplicationEditForm";
 

--- a/frontend/src/main/components/RiderApplication/RiderApplicationForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationForm.js
@@ -14,7 +14,7 @@ function RiderApplicationForm({ initialContents, submitAction, buttonLabel = "Ap
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "RiderApplicationForm";
 

--- a/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationShowForm.js
@@ -13,7 +13,7 @@ function RiderApplicationShowForm({ initialContents, buttonLabel = "Back", email
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
+    // Stryker restore all
    
     const testIdPrefix = "RiderApplicationShowForm";
 

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -18,7 +18,7 @@ export default function UsersTable({ users}) {
         {},
         ["/api/admin/users"]
     );
-    // Stryker enable all 
+    // Stryker restore all 
 
      // Stryker disable next-line all : TODO try to make a good test for this
     const toggleRiderCallback = async (cell) => { toggleRiderMutation.mutate(cell); }
@@ -40,7 +40,7 @@ export default function UsersTable({ users}) {
         {},
         ["/api/admin/users"]
     );
-    // Stryker enable all 
+    // Stryker restore all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const toggleAdminCallback = async (cell) => { toggleAdminMutation.mutate(cell); }
@@ -63,7 +63,7 @@ export default function UsersTable({ users}) {
         {},
         ["/api/admin/users"]
     );
-    // Stryker enable all 
+    // Stryker restore all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const toggleDriverCallback = async (cell) => { toggleDriverMutation.mutate(cell); }

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -72,7 +72,7 @@ export function useBackendMutation(objectToAxiosParams, useMutationParams, query
             if (queryKey !== null)
                 queryClient.invalidateQueries(queryKey);
         },
-        // Stryker enable all
+        // Stryker restore all
         retry: false,
         ...useMutationParams
     })


### PR DESCRIPTION
Changed all occurrences of `// Stryker enable all` to `// Stryker restore all` to properly re-enable all mutants from that line on.

Looks like this issue has been overlooked in previous years. I wanted to bring it to your attention, but I don't think I'll be able to resolve the mutation test failures so I will most likely be closing this PR.