### PR TITLE
Yuji - Different Drivers for Create Shift 

### DIFF
--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -9,6 +9,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         register,
         formState: { errors },
         handleSubmit,
+        watch,
     } = useForm({ defaultValues: initialContents || {} });
     // Stryker restore all
     const navigate = useNavigate();
@@ -22,6 +23,14 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             []
             // Stryker restore all 
         );
+
+    const selectedMainDriver = watch("driverID");
+    const validateBackupDriver = (value) => {
+        if (value === selectedMainDriver) {
+            return "Backup driver cannot be the same as the main driver.";
+        }
+        return true;
+    };
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -147,6 +156,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     isInvalid={Boolean(errors.driverBackupID)}
                     {...register("driverBackupID", {
                         required: "Driver Backup ID is required.",
+                        validate: validateBackupDriver
                     })}
                 >
                     <option value="">Select a driver</option>

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -122,6 +122,36 @@ describe("ShiftForm tests", () => {
         expect(screen.getByTestId("ShiftForm-submit")).toBeInTheDocument();
     });
 
+    test("validates that backup driver cannot be the same as the main driver", async () => { 
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ShiftForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        // Select the same driver for both driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
+        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "1" } });
+
+        // Try to submit the form
+        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
+
+        // Check for the validation message
+        await waitFor(() => expect(screen.getByText("Backup driver cannot be the same as the main driver.")).toBeInTheDocument());
+
+        // Select different drivers for driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("ShiftForm-driverID"), { target: { value: "1" } });
+        fireEvent.change(screen.getByTestId("ShiftForm-driverBackupID"), { target: { value: "2" } });
+
+        // Try to submit the form again
+        fireEvent.click(screen.getByTestId("ShiftForm-submit"));
+
+        // Check that the validation message is not present
+        await waitFor(() => expect(screen.queryByText("Backup driver cannot be the same as the main driver.")).not.toBeInTheDocument());
+    });
+
     test("validates time format", async () => {
         render(
             <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
### Issue to fix
Currently, the main driver and backup driver can be selected as the same person.

### Changes for Create Shift
Added an additional check to ensure that the main driver and backup driver cannot be the same person.
Made a test to validate that main and backup drivers have to be a different person.

Dokku Deployment: https://proj-gauchoride-yuji-sakaguchi-dev.dokku-14.cs.ucsb.edu/

Closes #49 

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/2697046d-0973-4488-95bb-d01f912e3dc3)