### PR TITLE
Yuji - Driver Availability End Time has to be later than Start Time 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "bootstrap": "^5.0.0-beta3",
+        "date-fns": "^3.6.0",
         "history": "^5.2.0",
         "react": "^17.0.1",
         "react-bootstrap": "^2.0.0-alpha.0",
@@ -16518,6 +16519,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/date-format": {
@@ -48272,6 +48282,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "date-format": {
       "version": "4.0.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.21.1",
     "babel-loader": "8.1.0",
     "bootstrap": "^5.0.0-beta3",
+    "date-fns": "^3.6.0",
     "history": "^5.2.0",
     "react": "^17.0.1",
     "react-bootstrap": "^2.0.0-alpha.0",

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -21,7 +21,6 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
     const startTime = watch("startTime");
 
     const validateEndTime = (endTime) => {
-        if (!startTime || !endTime) return true;
         const format = "hh:mma";
         const start = parse(startTime, format, new Date());
         const end = parse(endTime, format, new Date());

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -1,6 +1,7 @@
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
+import { parse, isBefore } from 'date-fns';
 
 function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     // Stryker disable all
@@ -8,6 +9,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
         register,
         formState: { errors },
         handleSubmit,
+        watch
     } = useForm(
         { defaultValues: initialContents || {}, }
     );
@@ -15,6 +17,17 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
     const navigate = useNavigate();
 
     const testIdPrefix = "DriverAvailabilityForm";
+
+    const startTime = watch("startTime");
+
+    const validateEndTime = (endTime) => {
+        if (!startTime || !endTime) return true;
+        const format = "hh:mma";
+        const start = parse(startTime, format, new Date());
+        const end = parse(endTime, format, new Date());
+        return isBefore(start, end) || "End time must be later than start time.";
+    };
+
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
             {initialContents && (
@@ -107,7 +120,8 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
                             message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
-                          }
+                          },
+                          validate: validateEndTime
                     })}
                     placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"   
                     defaultValue={initialContents?.endTime}   

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -180,6 +180,35 @@ describe("DriverAvailabilityForm tests", () => {
 
     });
 
+    test("Error message when end time is not later than start time", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <DriverAvailabilityForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        // Select the same driver for both driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("DriverAvailabilityForm-startTime"), { target: { value: "11:00AM" } });
+        fireEvent.change(screen.getByTestId("DriverAvailabilityForm-endTime"), { target: { value: "10:00AM" } });
+
+        // Try to submit the form
+        fireEvent.click(screen.getByTestId("DriverAvailabilityForm-submit"));
+
+        // Check for the validation message
+        await waitFor(() => expect(screen.getByText("End time must be later than start time.")).toBeInTheDocument());
+
+        // Select different drivers for driverID and driverBackupID
+        fireEvent.change(screen.getByTestId("DriverAvailabilityForm-startTime"), { target: { value: "11:00AM" } });
+        fireEvent.change(screen.getByTestId("DriverAvailabilityForm-endTime"), { target: { value: "2:00PM" } });
+
+        // Try to submit the form again
+        fireEvent.click(screen.getByTestId("DriverAvailabilityForm-submit"));
+
+        // Check that the validation message is not present
+        await waitFor(() => expect(screen.queryByText("End time must be later than start time.")).not.toBeInTheDocument());
+    });
    
     test("Error messages on bad time format", async () => {
         const mockSubmitAction = jest.fn();


### PR DESCRIPTION
### Issue to fix
Currently, the Driver availability start times and end times can be set to anything. This doesn't make sense since you can't be available from 11:00AM-10:00AM on the same day.

### Changes for Driver Availability
Added an additional check to ensure that Driver availability end time has to be later than Driver availability start time.
Made a test to validate that Driver availability end time has to be later than Driveravailability start time.
package.json needs to be updated with date-fns to handle date and time parsing and comparison in a reliable manner.

Dokku Deployment: Waiting for other PRs to be merged

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/86a6df28-6be6-4bab-93df-8710770dabc5)
