### PR TITLE
Yuji - Request Ride End Time has to be later than Start Time

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "bootstrap": "^5.0.0-beta3",
+        "date-fns": "^3.6.0",
         "history": "^5.2.0",
         "react": "^17.0.1",
         "react-bootstrap": "^2.0.0-alpha.0",
@@ -16518,6 +16519,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/date-format": {
@@ -48272,6 +48282,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
     },
     "date-format": {
       "version": "4.0.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.21.1",
     "babel-loader": "8.1.0",
     "bootstrap": "^5.0.0-beta3",
+    "date-fns": "^3.6.0",
     "history": "^5.2.0",
     "react": "^17.0.1",
     "react-bootstrap": "^2.0.0-alpha.0",

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Button, Form, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
-
-
+import { parse, isBefore } from 'date-fns';
 
 function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     const navigate = useNavigate();
@@ -13,6 +12,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         register,
         formState: { errors },
         handleSubmit,
+        watch
     } = useForm(
         { defaultValues: initialContents }
     );
@@ -20,6 +20,14 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
    
     const testIdPrefix = "RideForm";
 
+    const startTime = watch("start");
+
+    const validateEndTime = (endTime) => {
+        const format = "hh:mma";
+        const start = parse(startTime, format, new Date());
+        const end = parse(endTime, format, new Date());
+        return isBefore(start, end) || "End time must be later than start time.";
+    };
 
     return (
 
@@ -111,7 +119,8 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
                             message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
-                          }
+                        },
+                        validate: validateEndTime
                     })}
                     placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"   
                     defaultValue={initialContents?.endTime}     

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -113,7 +113,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     data-testid={testIdPrefix + "-end"}
                     id="end"
                     type="text"
-                    isInvalid={Boolean(errors.start) }
+                    isInvalid={Boolean(errors.end) }
                     {...register("end", {
                         required: "Drop Off Time is required.",
                         pattern: {

--- a/frontend/src/tests/components/Ride/RideForm.test.js
+++ b/frontend/src/tests/components/Ride/RideForm.test.js
@@ -74,4 +74,37 @@ describe("RideForm tests", () => {
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
+    test("validates that end time cannot be earlier than start time", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <RideForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        // Select a day
+        fireEvent.change(screen.getByTestId("RideForm-day"), { target: { value: "Monday" } });
+
+        // Set invalid times
+        fireEvent.change(screen.getByTestId("RideForm-start"), { target: { value: "11:00AM" } });
+        fireEvent.change(screen.getByTestId("RideForm-end"), { target: { value: "10:00AM" } });
+
+        // Try to submit the form
+        fireEvent.click(screen.getByTestId("RideForm-submit"));
+
+        // Check for the validation message
+        await waitFor(() => expect(screen.getByText("End time must be later than start time.")).toBeInTheDocument());
+
+        // Set valid times
+        fireEvent.change(screen.getByTestId("RideForm-start"), { target: { value: "11:00AM" } });
+        fireEvent.change(screen.getByTestId("RideForm-end"), { target: { value: "11:30AM" } });
+
+        // Try to submit the form again
+        fireEvent.click(screen.getByTestId("RideForm-submit"));
+
+        // Check that the validation message is not present
+        await waitFor(() => expect(screen.queryByText("End time must be later than start time.")).not.toBeInTheDocument());
+    });
+
 });


### PR DESCRIPTION
### Issue to fix
Currently, the Request Ride start times and end times can be set to anything. This doesn't make sense since you can't request to be picked up at 11:00AM and dropped off at 10:00AM.

### Changes for Request Ride
Added an additional check to ensure that Request Ride end time has to be later than Request Ride start time.
Made a test to validate that Request Ride end time has to be later than Request Ride start time.
package.json needs to be updated with date-fns to handle date and time parsing and comparison in a reliable manner.

Dokku Deployment: Waiting for other PRs to be merged

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/92128100/616b1390-8bee-4004-aaea-9d7bba3d2e1a)