### PR TITLE
Lindsey - Driver Availability Backend + Corresponding Frontend Changes

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -31,34 +31,17 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
         <Form onSubmit={handleSubmit(submitAction)}>
             {initialContents && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="id">id</Form.Label>
+                    <Form.Label htmlFor="id">Driver Id</Form.Label>
                     <Form.Control
-                        data-testid={testIdPrefix + "-id"}
-                        id="id"
+                        data-testid={testIdPrefix + "-driverId"}
+                        id="driverId"
                         type="text"
-                        {...register("id")}
-                        value={initialContents.id}
+                        {...register("driverId")}
+                        value={initialContents.driverId}
                         disabled
                     />
                 </Form.Group>
             )}
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="driverId">Driver Id</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-driverId"}
-                    id="driverId"
-                    type="text"
-                    isInvalid={Boolean(errors.driverId)}
-                    {...register("driverId", {
-                        required: "Driver Id is required.",
-                    })}
-                    placeholder="e.g. 1"   
-                    defaultValue={initialContents?.driverId}  
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverId?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="day">Day</Form.Label>

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -29,9 +29,9 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
-            {initialContents && (
+            {initialContents?.driverId && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="id">Driver Id</Form.Label>
+                    <Form.Label htmlFor="driverId">Driver Id</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-driverId"}
                         id="driverId"

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -53,6 +53,9 @@ describe("DriverAvailabilityForm tests", () => {
             expect(header).toBeInTheDocument();
         });
 
+        expect(await screen.findByTestId(`${testId}-driverId`)).toBeInTheDocument();
+        expect(screen.getByText("Driver Id")).toBeInTheDocument();
+
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
         expect(screen.getByText("Day")).toBeInTheDocument();
 
@@ -96,7 +99,6 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByText(/Create/);
         fireEvent.click(submitButton);
 
-        // await screen.findByText(/Driver Id is required./);
         await screen.findByText(/Day is required./);
         expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
         expect(screen.getByText(/End Time is required./)).toBeInTheDocument();

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("DriverAvailabilityForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Driver Id", "Day", "Start Time", "End Time", "Notes"];
+    const expectedHeaders = ["Day", "Start Time", "End Time", "Notes"];
     const testId = "DriverAvailabilityForm";
 
     test("renders correctly with no initialContents", async () => {
@@ -52,12 +52,6 @@ describe("DriverAvailabilityForm tests", () => {
             const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
-
-        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
-        expect(screen.getByText(`id`)).toBeInTheDocument();
-
-        expect(await screen.findByTestId(`${testId}-driverId`)).toBeInTheDocument();
-        expect(screen.getByText("Driver Id")).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
         expect(screen.getByText("Day")).toBeInTheDocument();
@@ -102,8 +96,8 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByText(/Create/);
         fireEvent.click(submitButton);
 
-        await screen.findByText(/Driver Id is required./);
-        expect(screen.getByText(/Day is required./)).toBeInTheDocument();
+        // await screen.findByText(/Driver Id is required./);
+        await screen.findByText(/Day is required./);
         expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
         expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
         expect(screen.getByText(/Notes is required./)).toBeInTheDocument();
@@ -120,16 +114,14 @@ describe("DriverAvailabilityForm tests", () => {
                 <DriverAvailabilityForm submitAction={mockSubmitAction} />
             </Router>
         );
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
         fireEvent.change(dayField, { target: { value: 'Tuesday' } });
         fireEvent.change(startTimeField, { target: { value: '3:15PM' } });
         fireEvent.change(endTimeField, { target: { value: '4:15PM' } });
@@ -138,7 +130,6 @@ describe("DriverAvailabilityForm tests", () => {
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/Driver Id is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Start Time is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/End Time is required./)).not.toBeInTheDocument();
@@ -156,24 +147,21 @@ describe("DriverAvailabilityForm tests", () => {
                 <DriverAvailabilityForm submitAction={mockSubmitAction} />
             </Router>
         );
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        fireEvent.change(driverIdField, { target: { value: '' } });
         fireEvent.change(dayField, { target: { value: '' } });
         fireEvent.change(startTimeField, { target: { value: '' } });
         fireEvent.change(endTimeField, { target: { value: '' } });
         fireEvent.change(notesField, { target: { value: '' } });
         fireEvent.click(submitButton);
 
-        expect(await screen.findByText(/Driver Id is required./)).toBeInTheDocument();
-        expect(screen.queryByText(/Day is required./)).toBeInTheDocument();
+        await screen.findByText(/Day is required./);        
         expect(screen.queryByText(/Start Time is required./)).toBeInTheDocument();
         expect(screen.queryByText(/End Time is required./)).toBeInTheDocument();
         expect(screen.queryByText(/Notes is required./)).toBeInTheDocument();
@@ -219,17 +207,14 @@ describe("DriverAvailabilityForm tests", () => {
             </Router>
         );
 
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        // Invalid start time format
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
         fireEvent.change(dayField, { target: { value: 'Tuesday' } });
         fireEvent.change(startTimeField, { target: { value: '315PM' } });
         fireEvent.change(endTimeField, { target: { value: '4:15PM' } });
@@ -251,17 +236,14 @@ describe("DriverAvailabilityForm tests", () => {
             </Router>
         );
 
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        // Invalid start time format
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
         fireEvent.change(dayField, { target: { value: 'Tuesday' } });
         fireEvent.change(startTimeField, { target: { value: 'a3:15PM' } });
         fireEvent.change(endTimeField, { target: { value: 'a4:15PM' } });
@@ -285,16 +267,14 @@ describe("DriverAvailabilityForm tests", () => {
             </Router>
         );
 
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
         fireEvent.change(dayField, { target: { value: 'Tuesday' } });
         fireEvent.change(startTimeField, { target: { value: '3:15PMa' } });
         fireEvent.change(endTimeField, { target: { value: '4:15PMa' } });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -10,85 +10,84 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-    const originalModule = jest.requireActual('react-router-dom');
-    return {
-        __esModule: true,
-        ...originalModule,
-        Navigate: (x) => { mockNavigate(x); return null; }
-    };
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
 });
 
 describe("DriverAvailabilityCreatePage tests", () => {
-
-    const axiosMock = new AxiosMockAdapter(axios);
+  const axiosMock = new AxiosMockAdapter(axios);
 
     beforeEach(() => {
         jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
     });
 
     const queryClient = new QueryClient();
     test("renders without crashing", () => {
         render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <DriverAvailabilityCreatePage />
-                </MemoryRouter>
-            </QueryClientProvider>
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+            <DriverAvailabilityCreatePage />
+            </MemoryRouter>
+        </QueryClientProvider>
         );
     });
 
     test("on submit, makes request to backend, and redirects to /availability", async () => {
-
         const queryClient = new QueryClient();
         const availability = {
-            id: 5,
-            driverId: 3,
-            day: "Saturday",
-            startTime: "11:40AM",
-            endTime: "11:59AM",
-            notes: "none",
+        id: 5,
+        day: "Saturday",
+        startTime: "11:40AM",
+        endTime: "11:59AM",
+        notes: "none",
         };
         const noidavailability = {
-            driverId: "3",
-            day: "Saturday",
-            startTime: "11:40AM",
-            endTime: "11:59AM",
-            notes: "none",
-        }
+        day: "Saturday",
+        startTime: "11:40AM",
+        endTime: "11:59AM",
+        notes: "none",
+        };
 
         axiosMock.onPost("/api/driverAvailability/new").reply(202, availability);
 
         render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <DriverAvailabilityCreatePage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        )
-
-
-        const driverIdInput = screen.getByLabelText("Driver Id")
-        await waitFor(() => {
-            expect(driverIdInput).toBeInTheDocument();
-        });
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+            <DriverAvailabilityCreatePage />
+            </MemoryRouter>
+        </QueryClientProvider>
+        );
 
         const dayInput = screen.getByLabelText("Day");
+        await waitFor(() => {
         expect(dayInput).toBeInTheDocument();
+        });
 
         const startTimeInput = screen.getByLabelText("Start Time");
         expect(startTimeInput).toBeInTheDocument();
@@ -101,25 +100,50 @@ describe("DriverAvailabilityCreatePage tests", () => {
 
         // Simulating filling out the form
         fireEvent.change(dayInput, { target: { value: availability.day } });
-        fireEvent.change(startTimeInput, { target: { value: availability.startTime } });
+        fireEvent.change(startTimeInput, {
+        target: { value: availability.startTime },
+        });
         fireEvent.change(endTimeInput, { target: { value: availability.endTime } });
-        fireEvent.change(driverIdInput, { target: { value: String(availability.driverId) } });
-        fireEvent.change(notesInput, { target: { value: String(availability.notes) } });
+        // fireEvent.change(driverIdInput, { target: { value: String(availability.driverId) } });
+        fireEvent.change(notesInput, {
+        target: { value: String(availability.notes) },
+        });
 
-        const createButton = screen.getByRole('button', { name: /Create/ });
+        const createButton = screen.getByRole("button", { name: /Create/ });
 
         fireEvent.click(createButton);
 
         // Wait for the axios call to be made
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
-
-        // Asserting that the post request was made with correct parameters
         expect(axiosMock.history.post[0].params).toEqual(noidavailability);
 
-        // Assert that the toast and navigate functions were called with expected values
-        expect(mockToast).toBeCalledWith(`New Driver Availability Created - id: ${availability.id}`);
-        expect(mockNavigate).toBeCalledWith({ "to": "/availability/" });
+        expect(mockToast).toBeCalledWith(
+        `New Driver Availability Created - id: ${availability.id}`
+        );
+        expect(mockNavigate).toBeCalledWith({ to: "/availability/" });
+    });
 
+    test("missing input should fail", async () => {
+        const queryClient = new QueryClient();
+        const availability = {};
+
+        axiosMock.onPost("/api/driverAvailability/new").reply(202, availability);
+
+        render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+            <DriverAvailabilityCreatePage />
+            </MemoryRouter>
+        </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Day is required./);
+        expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes is required./)).toBeInTheDocument();
     });
 });
-

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
@@ -84,7 +84,7 @@ describe("DriverAvailabilityEditPage tests", () => {
             });
             axiosMock.onPut('/api/driverAvailability').reply(200, {
                 id: 17,
-                driverId: 1,
+                driverId: 2,
                 day: "Monday",
                 startTime: "03:30PM",
                 endTime: "04:30PM",
@@ -119,13 +119,11 @@ describe("DriverAvailabilityEditPage tests", () => {
             const dayField = getByTestId("DriverAvailabilityForm-day");
             const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
             const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
-            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
             const notesField = getByTestId("DriverAvailabilityForm-notes");
 
             expect(dayField).toHaveValue("Tuesday");
             expect(startTimeField).toHaveValue("05:00PM");
             expect(endTimeField).toHaveValue("07:30PM");
-            expect(driverIdField).toHaveValue("2");
             expect(notesField).toHaveValue("none");
         });
 
@@ -144,13 +142,11 @@ describe("DriverAvailabilityEditPage tests", () => {
             const dayField = getByTestId("DriverAvailabilityForm-day");
             const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
             const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
-            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
             const notesField = getByTestId("DriverAvailabilityForm-notes");
 
             expect(dayField).toHaveValue("Tuesday");
             expect(startTimeField).toHaveValue("05:00PM");
             expect(endTimeField).toHaveValue("07:30PM");
-            expect(driverIdField).toHaveValue("2");
             expect(notesField).toHaveValue("none");
             
             const updateButton = screen.getByRole('button', { name: /Update/ });
@@ -159,7 +155,6 @@ describe("DriverAvailabilityEditPage tests", () => {
             fireEvent.change(dayField, { target: { value: 'Monday' } });
             fireEvent.change(startTimeField, { target: { value: '03:30PM' } });
             fireEvent.change(endTimeField, { target: { value: "04:30PM" } });
-            fireEvent.change(driverIdField, { target: { value: 1 } });
             fireEvent.change(notesField, { target: { value: "important" } });
         
             fireEvent.click(updateButton);
@@ -175,12 +170,12 @@ describe("DriverAvailabilityEditPage tests", () => {
 
             expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-                driverId: "1",
+                driverId: 2,
                 day: "Monday",
                 startTime: "03:30PM",
                 endTime: "04:30PM",
                 notes: "important"
-            })); // posted object
+            })); // posted object 
         });
         
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -81,6 +81,9 @@ public class DriverAvailabilityController extends ApiController{
         DriverAvailability availability;
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
+            throw new EntityNotFoundException(DriverAvailability.class, id);
+        }
         return availability;
     }
 
@@ -113,7 +116,9 @@ public class DriverAvailabilityController extends ApiController{
             @Parameter(name="id") @RequestParam Long id) {
         DriverAvailability availability = driverAvailabilityRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-
+        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
+            throw new EntityNotFoundException(DriverAvailability.class, id);
+        }
         driverAvailabilityRepository.delete(availability);
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
@@ -130,6 +135,7 @@ public class DriverAvailabilityController extends ApiController{
         DriverAvailability availability;
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+                
         return availability;
     }
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -92,11 +92,14 @@ public class DriverAvailabilityController extends ApiController{
     @PreAuthorize("hasRole('ROLE_DRIVER')")
     @PutMapping("")
     public ResponseEntity<Object> updateDriverAvailability(
+                            @Parameter(name="id", description = "Long, Id of the driver availability to get", 
+                                        required = true)  
+                            @RequestParam Long id,
                             @RequestBody @Valid DriverAvailability incoming)
     {
         DriverAvailability availability;
-        availability = driverAvailabilityRepository.findById(getCurrentUser().getUser().getId())
-                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, getCurrentUser().getUser().getId()));
+        availability = driverAvailabilityRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
 
         availability.setDay(incoming.getDay());
         availability.setStartTime(incoming.getStartTime());

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -114,7 +114,7 @@ public class DriverAvailabilityController extends ApiController{
     // Edits an availability of any user if the current user is an admin
     @Operation(summary = "Edit an existing driver availability if the current user is an admin")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("")
+    @PutMapping("/admin")
     public ResponseEntity<Object> updateAnyDriverAvailability(
                             @Parameter(name = "id", description = "Long, Id of the driver availability to get", 
                                         required = true)  

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -81,9 +81,6 @@ public class DriverAvailabilityController extends ApiController{
         DriverAvailability availability;
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
-            throw new EntityNotFoundException(DriverAvailability.class, id);
-        }
         return availability;
     }
 
@@ -141,9 +138,6 @@ public class DriverAvailabilityController extends ApiController{
             @Parameter(name="id") @RequestParam Long id) {
         DriverAvailability availability = driverAvailabilityRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
-            throw new EntityNotFoundException(DriverAvailability.class, id);
-        }
         driverAvailabilityRepository.delete(availability);
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
@@ -160,7 +154,6 @@ public class DriverAvailabilityController extends ApiController{
         DriverAvailability availability;
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-                
         return availability;
     }
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -111,6 +111,28 @@ public class DriverAvailabilityController extends ApiController{
 
     }
 
+    // Edits an availability of any user if the current user is an admin
+    @Operation(summary = "Edit an existing driver availability if the current user is an admin")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public ResponseEntity<Object> updateAnyDriverAvailability(
+                            @Parameter(name = "id", description = "Long, Id of the driver availability to get", 
+                                        required = true)  
+                            @RequestParam Long id,
+                            @RequestBody @Valid DriverAvailability incoming)
+    {
+        DriverAvailability availability = driverAvailabilityRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+
+        availability.setDay(incoming.getDay());
+        availability.setStartTime(incoming.getStartTime());
+        availability.setEndTime(incoming.getEndTime());
+        availability.setNotes(incoming.getNotes());
+
+        driverAvailabilityRepository.save(availability);
+        return ResponseEntity.ok(availability);
+    }
+
     //DELETE for driver Availability
     @Operation(summary= "Delete a driver availability")
     @PreAuthorize("hasRole('ROLE_DRIVER')")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -38,7 +38,6 @@ public class DriverAvailabilityController extends ApiController{
     @PreAuthorize("hasRole('ROLE_DRIVER')")
     @PostMapping("/new")
     public DriverAvailability postDriverAvailability(
-            @Parameter(name="driverId") @RequestParam long driverId,
             @Parameter(name="day") @RequestParam String day,
             @Parameter(name="startTime") @RequestParam String startTime,
             @Parameter(name="endTime") @RequestParam String endTime,
@@ -49,7 +48,7 @@ public class DriverAvailabilityController extends ApiController{
         log.info("notes={}", notes);
 
         DriverAvailability driverAvailability = new DriverAvailability();
-        driverAvailability.setDriverId(driverId);
+        driverAvailability.setDriverId(getCurrentUser().getUser().getId());
         driverAvailability.setDay(day);
         driverAvailability.setStartTime(startTime);
         driverAvailability.setEndTime(endTime);
@@ -90,17 +89,12 @@ public class DriverAvailabilityController extends ApiController{
     @PreAuthorize("hasRole('ROLE_DRIVER')")
     @PutMapping("")
     public ResponseEntity<Object> updateDriverAvailability(
-                            @Parameter(name="id", description="long, Id of the driver availability to be edited", 
-                            required = true)
-                            @RequestParam Long id,
                             @RequestBody @Valid DriverAvailability incoming)
     {
         DriverAvailability availability;
+        availability = driverAvailabilityRepository.findById(getCurrentUser().getUser().getId())
+                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, getCurrentUser().getUser().getId()));
 
-        availability = driverAvailabilityRepository.findById(id)
-                    .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-
-        availability.setDriverId(incoming.getDriverId());
         availability.setDay(incoming.getDay());
         availability.setStartTime(incoming.getStartTime());
         availability.setEndTime(incoming.getEndTime());

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -183,8 +183,6 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @Test
     public void test_that_logged_in_driver_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
         
-        Long UserId = currentUserService.getCurrentUser().getUser().getId();
-
         DriverAvailability availability = DriverAvailability.builder()
                         .driverId(1)
                         .day("Tuesday")
@@ -256,10 +254,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @Test
     public void driver_can_edit_their_own_availability() throws Exception {
 
-        Long DriverId = currentUserService.getCurrentUser().getUser().getId();
-
         DriverAvailability availability_original = DriverAvailability.builder()
-                        .driverId(DriverId)
                         .day("Tuesday")
                         .startTime("10:30AM")
                         .endTime("2:30PM")
@@ -267,7 +262,6 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
                         .build();
 
         DriverAvailability availability_edited = DriverAvailability.builder()
-                        .driverId(7)
                         .day("Monday")
                         .startTime("5:00AM")
                         .endTime("12:00PM")
@@ -276,18 +270,18 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         String requestBody = mapper.writeValueAsString(availability_edited);
 
-        when(driverAvailabilityRepository.findById(eq(67L))).thenReturn(Optional.of(availability_original));
+        when(driverAvailabilityRepository.findById(eq(1L))).thenReturn(Optional.of(availability_original));
 
         // act
         MvcResult response = mockMvc.perform(
-        put("/api/driverAvailability?id=67")
+        put("/api/driverAvailability?id=1")
                             .contentType(MediaType.APPLICATION_JSON)
                             .characterEncoding("utf-8")
                             .content(requestBody)
                             .with(csrf()))
             .andExpect(status().isOk()).andReturn();
         // assert
-        verify(driverAvailabilityRepository, times(1)).findById(eq(67L));
+        verify(driverAvailabilityRepository, times(1)).findById(eq(1L));
         verify(driverAvailabilityRepository, times(1)).save(availability_edited); // should be saved with correct user
         String responseString = response.getResponse().getContentAsString();
         assertEquals(requestBody, responseString);
@@ -298,10 +292,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     public void driver_cannot_edit_availability_that_does_not_exist() throws Exception {
             // arrange
 
-            Long DriverId = currentUserService.getCurrentUser().getUser().getId();
-
             DriverAvailability availability_edited = DriverAvailability.builder()
-                        .driverId(DriverId)
                         .day("Tuesday")
                         .startTime("5:00AM")
                         .endTime("12:00PM")
@@ -310,11 +301,11 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
                         
             String requestBody = mapper.writeValueAsString(availability_edited);
 
-            when(driverAvailabilityRepository.findById(eq(67L))).thenReturn(Optional.empty());
+            when(driverAvailabilityRepository.findById(eq(1L))).thenReturn(Optional.empty());
 
             // act
             MvcResult response = mockMvc.perform(
-                            put("/api/driverAvailability?id=67")
+                            put("/api/driverAvailability?id=1")
                                             .contentType(MediaType.APPLICATION_JSON)
                                             .characterEncoding("utf-8")
                                             .content(requestBody)
@@ -322,9 +313,9 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
                             .andExpect(status().isNotFound()).andReturn();
 
             // assert
-            verify(driverAvailabilityRepository, times(1)).findById(67L);
+            verify(driverAvailabilityRepository, times(1)).findById(1L);
             Map<String, Object> json = responseToJson(response);
-            assertEquals("DriverAvailability with id 67 not found", json.get("message"));
+            assertEquals("DriverAvailability with id 1 not found", json.get("message"));
 
     }
 


### PR DESCRIPTION
https://project-lindseywn.dokku-14.cs.ucsb.edu/
(when testing, make sure your driver role is toggled to true!)
Closes #32 
- it's having some bugs right now and i think it'll require more time and changes than i expected/have at the moment. the basic change of removing driverid from the form works, but changing that led to other issues which affected multiple files. 

- current bugs:
    - when admin edits someone else's availability, it takes them to their own availability page instead of back to the admin one
    - If admin user is not also a driver, will not be able to edit or delete
    
1. DONE: Modified DriverAvailabilityController.java POST so that when creating a new DriverAvailability we automatically use the creator's id and no longer take in id as an input.
2. DONE: Modify DriverAvailabilityController.java PUT so that when editing DriverAvailability we make sure that the DriverAvailability we intend to edit is really owned by the current user, and we no longer want to set the driver id to the incoming.
3. NOT DONE: Add the proper validations to GET single and DELETE so that a user can only delete or get their own availabilities and not anyone else

- Driver now does not need to type in their Driver Id each time when creating a new driver availability as it now automatically fills in the driver id with the user's current id
- Driver id will not be able to set to a different one, should be no option to edit driver id
- Users should only be able to see, and therefore edit/delete, their own if their role is only driver. If they are also admin then they still can see/edit/delete other availabilities through the admin tab

No option to type in driver id
<img width="1365" alt="Screen Shot 2024-05-29 at 9 01 01 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/b52950c1-e287-4267-9191-f8f567121dbd">

Driver id shows up even though user didn't type it in 
User can also only see their own unless they go through admin tab
<img width="1368" alt="Screen Shot 2024-05-29 at 9 02 01 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/122336146/69b14391-6dd1-4d52-be15-816694bd7b81">