### PR TITLE
Wesley - FIX Github repo link being hardcoded

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -1,12 +1,14 @@
 const systemInfoFixtures = {
-    showingBoth: {
-      springH2ConsoleEnabled: true,
-      showSwaggerUILink: true
-    },
-    showingNeither: {
-      springH2ConsoleEnabled: false,
-      showSwaggerUILink: false
-    },
-  };
-  
+  showingBoth: {
+    springH2ConsoleEnabled: true,
+    showSwaggerUILink: true,
+    sourceRepo: "https://github.com/ucsb-cs156/proj-gauchoride"
+  },
+  showingNeither: {
+    springH2ConsoleEnabled: false,
+    showSwaggerUILink: false,
+    sourceRepo: "https://github.com/ucsb-cs156/proj-gauchoride"
+  },
+};
+
 export { systemInfoFixtures };

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,8 +1,19 @@
 import { Container } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
 
 export const space = " ";
 
 export default function Footer() {
+  
+  const { data: systemInfo, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/systemInfo"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/systemInfo" },
+            []
+        );
+  
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
@@ -26,7 +37,7 @@ export default function Footer() {
           {space}
           <a
             data-testid="footer-source-code-link"
-            href={"https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2"}
+            href={systemInfo["sourceRepo"]}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,11 +1,34 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import Footer, { space } from "main/components/Nav/Footer";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 describe("Footer tests", () => {
+
+    const queryClient = new QueryClient();
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    
+    const setupSystemInfo = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingBoth);
+    };
+
     test("renders correctly ", async () => {
+        setupSystemInfo();
         const { getByText } = render(
-            <Footer />
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <Footer />
+                </MemoryRouter>
+            </QueryClientProvider>
         );
+
         await waitFor(() => expect(getByText(/This app is a class project/)).toBeInTheDocument());
         await waitFor(() => expect(getByText(/The cartoon Storke Tower images/)).toBeInTheDocument());
     });
@@ -15,7 +38,15 @@ describe("Footer tests", () => {
     });
 
     test("Links are correct", async () => {
-        render(<Footer />)
+        setupSystemInfo();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <Footer />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
             "href",
             "https://ucsb-cs156.github.io"
@@ -26,7 +57,7 @@ describe("Footer tests", () => {
         );
         expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
             "href",
-            "https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2"
+            "https://github.com/ucsb-cs156/proj-gauchoride"
         );
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(
             "href",
@@ -40,7 +71,15 @@ describe("Footer tests", () => {
     });
 
     test("Link is correct", async () => {
-        render(<Footer />)
+        setupSystemInfo();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <Footer />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(
           "href",
           "https://www.as.ucsb.edu/sticker-packs"


### PR DESCRIPTION
Closes #17 

Summary of issue: Currently, the link to the GauchoRide source repo at the footer of the home page is hardcoded to [s23-5pm-2](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2). In this PR, we use an API call to /api/systemInfo to fetch the main repo link.

Steps to verify issue:
1. Navigate to https://gauchoride.dokku-14.cs.ucsb.edu/
2. Verify the link in "Check out the source code on GitHub" leads to an outdated source repo link.

Steps to verify issue no longer persists:
1. Navigate to https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/
*Many /api/systemInfo error toasts will pop up, but these are to be resolved in a quick fix in separate issue #38.*
2. Log in
3. Verify the link in "Check out the source code on GitHub" leads to [https://github.com/ucsb-cs156/proj-gauchoride](proj-gauchoride).

Image:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/55602614/cc0f133f-ccbd-4dcf-a411-724f8641379e)
