### PR TITLE
Wesley - Make systemInfo available when not logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ will likely see an error such as:
 
 <img src="https://user-images.githubusercontent.com/1119017/149858436-c9baa238-a4f7-4c52-b995-0ed8bee97487.png" alt="Authorization Error; Error 401: invalid_client; The OAuth client was not found." width="400"/>
 
+Additionally, you will need to run the following commands on dokku:
+```
+dokku git:set [appname] keep-git-dir true
+dokku config:set [appname] SOURCE_REPO=https://ucsb-cs156-s24/proj-gauchoride
+```
+This allows the git-commit-id plugin to retrieve the project source repo link.
+
 # Getting Started on localhost
 
 * Open *two separate terminal windows*  

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,7 +25,6 @@ public class SystemInfoController extends ApiController {
     private SystemInfoService systemInfoService;
 
     @Operation(summary = "Get global information about the application")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoControllerTests.java
@@ -27,21 +27,7 @@ public class SystemInfoControllerTests extends ControllerTestCase {
   SystemInfoService mockSystemInfoService;
 
   @Test
-  public void systemInfo__logged_out() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void systemInfo__user_logged_in() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
-  }
-
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void systemInfo__admin_logged_in() throws Exception {
+  public void systemInfo__returns_expected() throws Exception {
 
     // arrange
 


### PR DESCRIPTION
Closes #38

Issue: /api/systemInfo is not available when a user is not logged in.

Verify issue:
1. Navigate to https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/ - do not log in
2. Navigate to https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/api/systemInfo
3. Verify user cannot access page
4. Log in as an admin user
5. Navigate to https://project-jeffsmithepic.dokku-14.cs.ucsb.edu/api/systemInfo
6. Verify systemInfo shows correctly

Verify issue no longer persists:
1. Navigate to https://project-jeffsmithepic-2.dokku-14.cs.ucsb.edu - do not log in
2. Navigate to https://project-jeffsmithepic-2.dokku-14.cs.ucsb.edu/api/systemInfo
3. Verify systemInfo shows correctly

Additionally, add the following documentation in setting a deployment's `keep-git-dir` and `SOURCE_REPO`:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-6/assets/55602614/ea272c8e-0534-426d-9810-70957cdb3a28)
