### PR TITLE
pc - fix commit info by making sure SOURCE_REPO can be used to override default

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ springdoc.swagger-ui.csrf.enabled=true
 
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-gauchoride}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false


### PR DESCRIPTION
In this PR, we add the omitted line in application.properties to ensure that the SOURCE_REPO env variable can be used to override the default.

Without this, the exposing commit info links don't work properly.